### PR TITLE
Make it stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ narrow-ui have limited default keymap, see [default keymap](https://github.com/t
   'space S': 'narrow:symbols'
   'space G': 'narrow:git-diff'
   'space B': 'narrow:bookmarks'
+
+'atom-workspace.has-narrow': # available only when some narrow was opened.
+  'ctrl-cmd-f': 'narrow:focus'
+  'ctrl-cmd-n': 'narrow:next-item'
+  'ctrl-cmd-p': 'narrow:previous-item'
 ```
 
 # vim-mode-plus integration.

--- a/README.md
+++ b/README.md
@@ -80,10 +80,13 @@ narrow-ui have limited default keymap, see [default keymap](https://github.com/t
   'space G': 'narrow:git-diff'
   'space B': 'narrow:bookmarks'
 
-'atom-workspace.has-narrow': # available only when some narrow was opened.
+# available only when some narrow was opened.
+'atom-workspace.has-narrow atom-text-editor.vim-mode-plus:not(.narrow)':
   'ctrl-cmd-f': 'narrow:focus'
-  'ctrl-cmd-n': 'narrow:next-item'
   'ctrl-cmd-p': 'narrow:previous-item'
+  'ctrl-cmd-n': 'narrow:next-item'
+  'up': 'narrow:previous-item'
+  'down': 'narrow:next-item'
 ```
 
 # vim-mode-plus integration.

--- a/keymaps/narrow.cson
+++ b/keymaps/narrow.cson
@@ -7,7 +7,7 @@
 'atom-text-editor.narrow.vim-mode-plus.normal-mode[data-grammar="source narrow"]':
   'enter': 'core:confirm'
   'q': 'core:close'
-  'o': 'narrow-ui:open-without-close'
+  'o': 'narrow-ui:confirm-keep-open'
   'u': 'narrow-ui:preview-item'
   'r': 'narrow-ui:toggle-auto-preview'
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -24,7 +24,7 @@ module.exports =
       if atom.workspace.isTextEditor(item) and @isNarrowEditor(item)
         @currentNarrowEditor = item
 
-    @subscriptions.add atom.commands.add 'atom-workspace',
+    @subscriptions.add atom.commands.add 'atom-text-editor',
       'narrow:lines': => @narrow('lines')
       'narrow:lines-by-current-word': => @narrow('lines', getUiOptions())
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,9 +1,7 @@
 {CompositeDisposable} = require 'atom'
-
-Search = require './provider/search'
-Input = require './input'
 settings = require './settings'
 UI = null
+getCurrentWord = null # delay
 
 module.exports =
   config: settings.config
@@ -13,33 +11,27 @@ module.exports =
   activate: ->
     @subscriptions = new CompositeDisposable
     settings.removeDeprecated()
-    @input = new Input
 
-    getUiOptions = =>
-      uiOptions:
-        initialInput: @getCurrentWord()
-
-    getCurrentWord = @getCurrentWord.bind(this)
     @subscriptions.add atom.workspace.observeActivePaneItem (item) =>
       if atom.workspace.isTextEditor(item) and @isNarrowEditor(item)
         @currentNarrowEditor = item
 
     @subscriptions.add atom.commands.add 'atom-text-editor',
       'narrow:lines': => @narrow('lines')
-      'narrow:lines-by-current-word': => @narrow('lines', getUiOptions())
+      'narrow:lines-by-current-word': => @narrow('lines', input: @getCurrentWord())
 
       'narrow:fold': => @narrow('fold')
-      'narrow:fold-by-current-word': => @narrow('fold', getUiOptions())
+      'narrow:fold-by-current-word': => @narrow('fold', input: @getCurrentWord())
 
       'narrow:symbols': => @narrow('symbols')
       'narrow:git-diff': => @narrow('git-diff')
       'narrow:bookmarks': => @narrow('bookmarks')
 
       'narrow:search': => @search()
-      'narrow:search-by-current-word': => @search(getCurrentWord())
+      'narrow:search-by-current-word': => @search(@getCurrentWord())
 
       'narrow:search-current-project': => @searchCurrentProject()
-      'narrow:search-current-project-by-current-word': => @searchCurrentProject(getCurrentWord())
+      'narrow:search-current-project-by-current-word': => @searchCurrentProject(@getCurrentWord())
 
       'narrow:focus': => @getUI()?.focus()
       'narrow:next-item': => @getUI()?.nextItem()
@@ -51,20 +43,10 @@ module.exports =
 
   # Return currently selected text or word under cursor.
   getCurrentWord: ->
-    editor = atom.workspace.getActiveTextEditor()
-    selection = editor.getLastSelection()
-    {cursor} = selection
+    getCurrentWord ?= require('./utils').getCurrentWord
+    getCurrentWord(atom.workspace.getActiveTextEditor())
 
-    if selection.isEmpty()
-      point = cursor.getBufferPosition()
-      selection.selectWord()
-      text = selection.getText()
-      cursor.setBufferPosition(point)
-      text
-    else
-      selection.getText()
-
-  narrow: (providerName, {uiOptions, providerOptions}={}) ->
+  narrow: (providerName, uiOptions, providerOptions) ->
     if providerName not of @providers
       @providers[providerName] = require("./provider/#{providerName}")
     klass = @providers[providerName]
@@ -84,13 +66,15 @@ module.exports =
       return
     @search(word, projects)
 
-  search: (word=null, projects=atom.project.getPaths()) ->
-    unless word?
-      @input.readInput().then (input) =>
-        @search(input, projects)
+  search: (word = null, projects = atom.project.getPaths()) ->
+    if word?
+      @narrow('search', initialKeyword: word, {word, projects})
+    else
+      @readInput().then (input) => @search(input, projects)
 
-    return unless word
-    new Search(initialKeyword: word, {word, projects})
+  readInput: ->
+    @input ?= new(require './input')
+    @input.readInput()
 
   deactivate: ->
     @subscriptions?.dispose()
@@ -118,11 +102,7 @@ module.exports =
       vimState.searchInput.confirm()
       return text
 
-    getUiOptions = ->
-      uiOptions:
-        initialInput: confirmSearch()
-
     @subscriptions.add atom.commands.add 'atom-text-editor.vim-mode-plus-search',
-      'vim-mode-plus-user:narrow-lines-from-search': => @narrow('lines', getUiOptions())
+      'vim-mode-plus-user:narrow-lines-from-search': => @narrow('lines', input: confirmSearch())
       'vim-mode-plus-user:narrow-search': => @search(confirmSearch())
       'vim-mode-plus-user:narrow-search-current-project': => @searchCurrentProject(confirmSearch())

--- a/lib/provider/bookmarks.coffee
+++ b/lib/provider/bookmarks.coffee
@@ -18,6 +18,8 @@ getBookmarks = ->
 
 module.exports =
 class Bookmarks extends ProviderBase
+  includeHeaderGrammarRules: true
+
   getItemsForEditor: (editor, markerLayer) ->
     filePath = editor.getPath()
     textWidthForLastRow = String(editor.getLastBufferRow()).length
@@ -42,7 +44,7 @@ class Bookmarks extends ProviderBase
     atom.workspace.open(filePath, pending: true).then (editor) ->
       editor.setCursorBufferPosition(point, autoscroll: false)
       editor.scrollToBufferPosition(point, center: true)
-      editor
+      return {editor, point}
 
   viewForItem: ({header, text, point, textWidthForLastRow}) ->
     if header?

--- a/lib/provider/bookmarks.coffee
+++ b/lib/provider/bookmarks.coffee
@@ -36,13 +36,11 @@ class Bookmarks extends ProviderBase
       items.push(@getItemsForEditor(editor, markerLayer)...)
     items
 
-  confirmed: (item, {preview}={}) ->
+  confirmed: (item) ->
     {filePath, point} = item
     @pane.activate()
-
-    openOptions = {activatePane: not preview, pending: true}
-    atom.workspace.open(filePath, openOptions).then (editor) ->
-      editor.setCursorBufferPosition(point, autoscroll: false) unless preview
+    atom.workspace.open(filePath, pending: true).then (editor) ->
+      editor.setCursorBufferPosition(point, autoscroll: false)
       editor.scrollToBufferPosition(point, center: true)
       editor
 

--- a/lib/provider/bookmarks.coffee
+++ b/lib/provider/bookmarks.coffee
@@ -38,14 +38,13 @@ class Bookmarks extends ProviderBase
 
   confirmed: (item, {preview}={}) ->
     {filePath, point} = item
-    @marker?.destroy()
     @pane.activate()
 
     openOptions = {activatePane: not preview, pending: true}
-    atom.workspace.open(filePath, openOptions).then (editor) =>
+    atom.workspace.open(filePath, openOptions).then (editor) ->
       editor.setCursorBufferPosition(point, autoscroll: false) unless preview
       editor.scrollToBufferPosition(point, center: true)
-      @marker = @highlightRow(editor, point.row) if preview
+      editor
 
   viewForItem: ({header, text, point, textWidthForLastRow}) ->
     if header?

--- a/lib/provider/fold.coffee
+++ b/lib/provider/fold.coffee
@@ -14,7 +14,7 @@ getCodeFoldStartRows = (editor, indentLevel) ->
 
 module.exports =
 class Fold extends ProviderBase
-  syncToEditor: true
+  boundToEditor: true
   
   foldLevel: 2
 

--- a/lib/provider/fold.coffee
+++ b/lib/provider/fold.coffee
@@ -14,6 +14,8 @@ getCodeFoldStartRows = (editor, indentLevel) ->
 
 module.exports =
 class Fold extends ProviderBase
+  syncToEditor: true
+  
   foldLevel: 2
 
   initialize: ->

--- a/lib/provider/git-diff.coffee
+++ b/lib/provider/git-diff.coffee
@@ -11,6 +11,8 @@ repositoryForPath = (goalPath) ->
 
 module.exports =
 class GitDiff extends ProviderBase
+  syncToEditor: true
+
   initialize: ->
     @subscribe @editor.onDidStopChanging(@refresh)
 

--- a/lib/provider/git-diff.coffee
+++ b/lib/provider/git-diff.coffee
@@ -11,7 +11,7 @@ repositoryForPath = (goalPath) ->
 
 module.exports =
 class GitDiff extends ProviderBase
-  syncToEditor: true
+  boundToEditor: true
 
   initialize: ->
     @subscribe @editor.onDidStopChanging(@refresh)

--- a/lib/provider/lines.coffee
+++ b/lib/provider/lines.coffee
@@ -3,6 +3,7 @@ ProviderBase = require './provider-base'
 
 module.exports =
 class Lines extends ProviderBase
+  syncToEditor: true
   initialize: ->
     @subscribe @editor.onDidStopChanging(@refresh)
 

--- a/lib/provider/lines.coffee
+++ b/lib/provider/lines.coffee
@@ -3,7 +3,7 @@ ProviderBase = require './provider-base'
 
 module.exports =
 class Lines extends ProviderBase
-  syncToEditor: true
+  boundToEditor: true
   initialize: ->
     @subscribe @editor.onDidStopChanging(@refresh)
 

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -55,15 +55,13 @@ class ProviderBase
     items
 
   destroy: ->
-    @marker?.destroy()
     @subscriptions.dispose()
     @restoreEditorState() unless @wasConfirmed
-    {@editor, @editorElement, @marker, @subscriptions} = {}
+    {@editor, @editorElement, @subscriptions} = {}
 
   confirmed: ({point}, options={}) ->
     unless options.preview
       @wasConfirmed = true
-    @marker?.destroy()
     return unless point?
     point = Point.fromObject(point)
 

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -43,15 +43,12 @@ class ProviderBase
   filterItems: (items, words) ->
     filterKey = @getFilterKey()
 
-    matchPattern = (item) ->
-      text = item[filterKey]
-      if text?
-        text.match(///#{pattern}///i)
-      else
-        true # When without filterKey is always displayed.
-
     for pattern, i in words.map(_.escapeRegExp)
-      items = items.filter(matchPattern)
+      items = items.filter (item) ->
+        if (text = item[filterKey])?
+          text.match(///#{pattern}///i)
+        else
+          true # items without filterKey is always displayed.
     items
 
   destroy: ->

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -20,12 +20,11 @@ class ProviderBase
   constructor: (uiOptions, @options={}) ->
     @subscriptions = new CompositeDisposable
     @editor = atom.workspace.getActiveTextEditor()
+    @editorElement = @editor.element
+    @pane = atom.workspace.paneForItem(@editor)
+    @restoreEditorState = saveEditorState(@editor)
 
     @subscribe @editor.onDidStopChanging(@invalidateState)
-
-    @editorElement = @editor.element
-    @pane = atom.workspace.getActivePane()
-    @restoreEditorState = saveEditorState(@editor)
 
     @ui = new UI(uiOptions)
     @initialize?()

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -4,6 +4,7 @@ _ = require 'underscore-plus'
   saveEditorState
   padStringLeft
 } = require '../utils'
+UI = require '../ui'
 
 module.exports =
 class ProviderBase
@@ -16,7 +17,7 @@ class ProviderBase
   getTitle: ->
     _.dasherize(@getName())
 
-  constructor: (@ui, @options={}) ->
+  constructor: (uiOptions, @options={}) ->
     @subscriptions = new CompositeDisposable
     @editor = atom.workspace.getActiveTextEditor()
 
@@ -26,6 +27,7 @@ class ProviderBase
     @pane = atom.workspace.getActivePane()
     @restoreEditorState = saveEditorState(@editor)
 
+    @ui = new UI(uiOptions)
     @initialize?()
     @ui.start(this)
 

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -10,7 +10,8 @@ module.exports =
 class ProviderBase
   wasConfirmed: false
   textWidthForLastRow: null
-  syncToEditor: false
+  boundToEditor: false
+  includeHeaderGrammarRules: false
 
   getName: ->
     @constructor.name
@@ -70,6 +71,8 @@ class ProviderBase
 
     @editor.scrollToBufferPosition(point, center: true)
     @editorElement.component.updateSync()
+
+    return {@editor, point}
 
   getLineNumberText: (row) ->
     @textWidthForLastRow ?= String(@editor.getLastBufferRow()).length

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -54,12 +54,6 @@ class ProviderBase
       items = items.filter(matchPattern)
     items
 
-  highlightRow: (editor, row) ->
-    point = [row, 0]
-    marker = editor.markBufferRange([point, point])
-    editor.decorateMarker(marker, type: 'line', class: 'narrow-result')
-    marker
-
   destroy: ->
     @marker?.destroy()
     @subscriptions.dispose()
@@ -75,7 +69,6 @@ class ProviderBase
 
     if options.preview?
       @pane.activateItem(@editor)
-      @marker = @highlightRow(@editor, point.row)
     else
       @editor.setCursorBufferPosition(point, autoscroll: false)
       @editor.moveToFirstCharacterOfLine()

--- a/lib/provider/search.coffee
+++ b/lib/provider/search.coffee
@@ -90,6 +90,7 @@ class Search extends ProviderBase
     atom.workspace.open(filePath, openOptions).then (editor) ->
       editor.setCursorBufferPosition(point, autoscroll: false)
       editor.scrollToBufferPosition(point, center: true)
+      editor
 
   filterItems: (items, words) ->
     filterKey = @getFilterKey()

--- a/lib/provider/search.coffee
+++ b/lib/provider/search.coffee
@@ -45,6 +45,8 @@ getOutputterForProject = (project, items) ->
 module.exports =
 class Search extends ProviderBase
   items: null
+  includeHeaderGrammarRules: true
+
   getItems: ->
     if @items?
       @items
@@ -74,7 +76,7 @@ class Search extends ProviderBase
     atom.workspace.open(filePath, pending: true).then (editor) ->
       editor.setCursorBufferPosition(point, autoscroll: false)
       editor.scrollToBufferPosition(point, center: true)
-      editor
+      return {editor, point}
 
   filterItems: (items, words) ->
     filterKey = @getFilterKey()

--- a/lib/provider/search.coffee
+++ b/lib/provider/search.coffee
@@ -7,8 +7,6 @@ ProviderBase = require './provider-base'
 module.exports =
 class Search extends ProviderBase
   items: null
-  searchersRunning: []
-
   search: (text, {cwd, onData, onFinish}) ->
     command = 'ag'
     args = ['--nocolor', '--column', text]
@@ -79,7 +77,6 @@ class Search extends ProviderBase
     process
 
   confirmed: (item, {preview}={}) ->
-    @marker?.destroy()
     return unless item.point?
 
     {filePath, point} = item

--- a/lib/provider/search.coffee
+++ b/lib/provider/search.coffee
@@ -50,8 +50,7 @@ class Search extends ProviderBase
     if @items?
       @items
     else
-      pattern = _.escapeRegExp(@options.word)
-      search = @search.bind(null, pattern)
+      search = @search.bind(null, _.escapeRegExp(@options.word))
       Promise.all(@options.projects.map(search)).then (values) =>
         @items = _.flatten(values)
 

--- a/lib/provider/search.coffee
+++ b/lib/provider/search.coffee
@@ -78,25 +78,18 @@ class Search extends ProviderBase
       handle()
     process
 
-  confirmed: (item, options={}) ->
+  confirmed: (item, {preview}={}) ->
     @marker?.destroy()
     return unless item.point?
 
-    {project, filePath, point} = item
+    {filePath, point} = item
     point = Point.fromObject(point)
 
     @pane.activate()
-
-    if options.preview?
-      openOptions = {activatePane: false, pending: true}
-      atom.workspace.open(filePath, openOptions).then (editor) =>
-        editor.scrollToBufferPosition(point, center: true)
-        @marker = @highlightRow(editor, point.row)
-    else
-      openOptions = {pending: true}
-      atom.workspace.open(filePath, openOptions).then (editor) ->
-        editor.setCursorBufferPosition(point, autoscroll: false)
-        editor.scrollToBufferPosition(point, center: true)
+    openOptions = {activatePane: not preview, pending: true}
+    atom.workspace.open(filePath, openOptions).then (editor) ->
+      editor.setCursorBufferPosition(point, autoscroll: false)
+      editor.scrollToBufferPosition(point, center: true)
 
   filterItems: (items, words) ->
     filterKey = @getFilterKey()

--- a/lib/provider/search.coffee
+++ b/lib/provider/search.coffee
@@ -45,7 +45,6 @@ getOutputterForProject = (project, items) ->
 module.exports =
 class Search extends ProviderBase
   items: null
-
   getItems: ->
     if @items?
       @items
@@ -69,15 +68,10 @@ class Search extends ProviderBase
           env: process.env
       )
 
-  confirmed: (item, {preview}={}) ->
-    return unless item.point?
-
-    {filePath, point} = item
-    point = Point.fromObject(point)
-
+  confirmed: ({filePath, point}) ->
+    return unless point?
     @pane.activate()
-    openOptions = {activatePane: not preview, pending: true}
-    atom.workspace.open(filePath, openOptions).then (editor) ->
+    atom.workspace.open(filePath, pending: true).then (editor) ->
       editor.setCursorBufferPosition(point, autoscroll: false)
       editor.scrollToBufferPosition(point, center: true)
       editor

--- a/lib/provider/symbols.coffee
+++ b/lib/provider/symbols.coffee
@@ -6,7 +6,7 @@ TagGenerator = requireFrom('symbols-view', 'tag-generator')
 
 module.exports =
 class Symbols extends ProviderBase
-  syncToEditor: true
+  boundToEditor: true
 
   initialize: ->
     @subscribe @editor.onDidSave(@refresh)

--- a/lib/provider/symbols.coffee
+++ b/lib/provider/symbols.coffee
@@ -6,6 +6,8 @@ TagGenerator = requireFrom('symbols-view', 'tag-generator')
 
 module.exports =
 class Symbols extends ProviderBase
+  syncToEditor: true
+
   initialize: ->
     @subscribe @editor.onDidSave(@refresh)
 

--- a/lib/provider/symbols.coffee
+++ b/lib/provider/symbols.coffee
@@ -17,8 +17,10 @@ class Symbols extends ProviderBase
     if @items?
       @items
     else
-      new TagGenerator(@editor.getPath(), @editor.getGrammar().scopeName).generate().then (tags) =>
-        # We show full line text of symbol's line, so just care for which line have symbols.
+      # We show full line text of symbol's line, so just care for which line have symbol.
+      filePath = @editor.getPath()
+      scopeName = @editor.getGrammar().scopeName
+      new TagGenerator(filePath, scopeName).generate().then (tags) =>
         tags = _.uniq(tags, (tag) -> tag.position.row)
         @items = tags.map ({position}) =>
           point: position

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -108,8 +108,8 @@ class UI
         if @items.length and item = @findNearestItem(@items)
           @selectItem(item)
 
-    @disposables.add atom.workspace.observeActivePaneItem (item) =>
-      if item is @provider.editor
+    @disposables.add atom.workspace.onDidStopChangingActivePaneItem (item) =>
+      if item isnt @narrowEditor
         @rowMarker?.destroy()
 
     activePane = atom.workspace.getActivePane()
@@ -215,11 +215,9 @@ class UI
     item = @getSelectedItem()
     done = @provider.confirmed(item, options)
     if options.preview and item.point and @provider.editor?
-      if done instanceof Promise
-        done.then =>
-          @rowMarker = @highlightRow(@provider.editor, Point.fromObject(item.point).row)
-      else
-        @rowMarker = @highlightRow(@provider.editor, Point.fromObject(item.point).row)
+      done = Promise.resolve(@provider.editor) unless done instanceof Promise
+      done.then (editor) =>
+        @rowMarker = @highlightRow(editor, Point.fromObject(item.point).row)
 
     unless options.preview or options.keepOpen
       @narrowEditor.destroy()

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -30,7 +30,7 @@ class UI
 
   constructor: (@provider, params={}) ->
     @disposables = new CompositeDisposable
-    {@initialKeyword, @initialInput} = params
+    {@initialKeyword, @input} = params
 
     @originalPane = atom.workspace.getActivePane()
     @gutterItem = document.createElement('span')
@@ -75,7 +75,7 @@ class UI
   registerCommands: ->
     atom.commands.add @narrowEditorElement,
       'core:confirm': => @confirm()
-      'narrow-ui:open-without-close': => @confirm(keepOpen: true)
+      'narrow-ui:confirm-keep-open': => @confirm(keepOpen: true)
       'narrow-ui:preview-item': => @preview()
       'narrow-ui:toggle-auto-preview': => @toggleAutoPreview()
 
@@ -145,8 +145,8 @@ class UI
 
     @getItems().then (items) =>
       @setItems(items)
-      if @initialInput
-        @narrowEditor.insertText(@initialInput)
+      if @input
+        @narrowEditor.insertText(@input)
 
   findNearestItem: (items) ->
     cursorPosition = @provider.editor.getCursorBufferPosition()
@@ -211,7 +211,7 @@ class UI
   preview: ->
     @confirm(keepOpen: true).then ({editor, item}) =>
       @rowMarker = @highlightRow(editor, Point.fromObject(item.point).row)
-    @focus()
+      @focus()
 
   isValidItem: (item) ->
     item? and not item.skip
@@ -283,8 +283,4 @@ class UI
     @items = [{_prompt: true, skip: true}, items...]
     texts = items.map (item) => @provider.viewForItem(item)
     @appendText(texts.join("\n"))
-
-    # if @provider.syncToEditor and item = @findNearestItem(items)
-    #   @selectItem(item)
-    # else
     @selectItemForRow(@findValidItem(1, 'next'))

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -10,8 +10,21 @@ NarrowGrammar = require './grammar'
 
 module.exports =
 class UI
+  @uiByNarrowEditor: new Map()
   autoPreview: false
   items: []
+
+  @unregisterUI: (narrowEditor) ->
+    @uiByNarrowEditor.delete(narrowEditor)
+    @updateWorkspaceClassList()
+
+  @registerUI: (narrowEditor, ui) ->
+    @uiByNarrowEditor.set(narrowEditor, ui)
+    @updateWorkspaceClassList()
+
+  @updateWorkspaceClassList: ->
+    workspaceElement = atom.views.getView(atom.workspace)
+    workspaceElement.classList.toggle('has-narrow', @uiByNarrowEditor.size)
 
   focus: ->
     if @isAlive()
@@ -38,6 +51,7 @@ class UI
     @originalPane.activate() if @originalPane.isAlive()
     @provider?.destroy?()
     @gutterMarker?.destroy()
+    @constructor.unregisterUI(@narrowEditor)
 
   registerCommands: ->
     atom.commands.add @narrowEditorElement,
@@ -203,6 +217,7 @@ class UI
     @registerCommands()
     @observeInputChange()
     @observeCursorPositionChangeForNarrowEditor()
+    @constructor.registerUI(@narrowEditor, this)
 
   # Return row
   findValidItem: (startRow, direction) ->

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -41,7 +41,6 @@ class UI
 
     @narrowEditorElement = @narrowEditor.element
     @narrowEditorElement.classList.add('narrow')
-    # @narrowEditorElement.classList.add(params.class) if params.class
 
     @narrowEditor.getTitle = => @provider?.getTitle()
     @narrowEditor.isModified = -> false
@@ -75,10 +74,9 @@ class UI
       when 'up' then @narrowEditor.moveUp()
       when 'down' then @narrowEditor.moveDown()
 
-    if preview
-      @preview()
-    else
-      @confirm(keepOpen: true)
+    unless preview
+      @confirm(keepOpen: true).then =>
+        @rowMarker?.destroy() # FIXME
 
   nextItem: (options) ->
     @moveUpDown('down', options)
@@ -185,7 +183,6 @@ class UI
 
   preview: ->
     @confirm(preview: true)
-    @focus()
 
   isValidItem: (item) ->
     item? and not item.skip
@@ -214,13 +211,15 @@ class UI
     @rowMarker?.destroy()
     item = @getSelectedItem()
     done = @provider.confirmed(item, options)
-    if options.preview and item.point and @provider.editor?
-      done = Promise.resolve(@provider.editor) unless done instanceof Promise
-      done.then (editor) =>
+    unless done instanceof Promise
+      done = Promise.resolve(@provider.editor)
+
+    done.then (editor) =>
+      if options.preview
         @rowMarker = @highlightRow(editor, Point.fromObject(item.point).row)
 
-    unless options.preview or options.keepOpen
-      @narrowEditor.destroy()
+      unless options.preview or options.keepOpen
+        @narrowEditor.destroy()
 
   # clear text from  2nd row to last row.
   clearItemsText: ->

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -59,18 +59,31 @@ class UI
       'narrow-ui:open-without-close': => @confirm(keepOpen: true)
       'narrow-ui:preview-item': => @preview()
       'narrow-ui:toggle-auto-preview': => @toggleAutoPreview()
+      'core:move-down': (event) =>
+        event.stopImmediatePropagation()
+        @nextItem(preview: true)
+      'core:move-up': (event) =>
+        event.stopImmediatePropagation()
+        @previousItem(preview: true)
 
-  nextItem: ->
+  moveUpDown: (direction, {preview}={}) ->
     if (row = @getRowForSelectedItem()) >= 0
       @withLock => @narrowEditor.setCursorBufferPosition([row, 0])
-    @narrowEditor.moveDown()
-    @confirm(keepOpen: true)
 
-  previousItem: ->
-    if (row = @getRowForSelectedItem()) >= 0
-      @withLock => @narrowEditor.setCursorBufferPosition([row, 0])
-    @narrowEditor.moveUp()
-    @confirm(keepOpen: true)
+    switch direction
+      when 'up' then @narrowEditor.moveUp()
+      when 'down' then @narrowEditor.moveDown()
+
+    if preview
+      @preview()
+    else
+      @confirm(keepOpen: true)
+
+  nextItem: (options) ->
+    @moveUpDown('down', options)
+
+  previousItem: (options) ->
+    @moveUpDown('up', options)
 
   isAutoPreview: ->
     @autoPreview

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -183,6 +183,7 @@ class UI
 
   preview: ->
     @confirm(preview: true)
+    @focus()
 
   isValidItem: (item) ->
     item? and not item.skip

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -65,6 +65,20 @@ limitNumber = (number, {max, min}={}) ->
   number = Math.max(number, min) if min?
   number
 
+getCurrentWord = (editor) ->
+  editor = atom.workspace.getActiveTextEditor()
+  selection = editor.getLastSelection()
+  {cursor} = selection
+
+  if selection.isEmpty()
+    point = cursor.getBufferPosition()
+    selection.selectWord()
+    text = selection.getText()
+    cursor.setBufferPosition(point)
+    text
+  else
+    selection.getText()
+
 module.exports = {
   getAdjacentPaneForPane
   openItemInAdjacentPaneForPane
@@ -74,4 +88,5 @@ module.exports = {
   saveEditorState
   requireFrom
   limitNumber
+  getCurrentWord
 }

--- a/styles/narrow.less
+++ b/styles/narrow.less
@@ -1,22 +1,6 @@
 @import "ui-variables";
 @import "syntax-variables";
 
-@red-color: @syntax-color-removed;
-@green-color: @syntax-color-added;
-@blue-color: @syntax-color-renamed;
-
-.round-box () {
-  box-sizing: border-box;
-  border-radius: @component-border-radius;
-  border-width: 1px;
-  border-style: solid;
-}
-
-// Bollowed from linter
-div.narrow-section {
-  color: lighten(@text-color-success, 5%);
-}
-
 atom-text-editor .narrow-ui-row {
   /* Take up the full allowed width */
   left: 0;
@@ -24,28 +8,12 @@ atom-text-editor .narrow-ui-row {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: @green-color;
+  color: @syntax-color-added;
 }
 
 @line-marker: fadeout(lighten(@syntax-color-added, 0%), 20%);
-// @line-marker: lighten(@syntax-color-added, 0%);
-// @line-marker: fadeout(@syntax-color-modified, 60%);
 
 atom-text-editor {
-  .narrow-match .region {
-    .round-box;
-    background-color: transparent;
-    border: 1px solid @syntax-result-marker-color;
-  }
-  .narrow-flash .region {
-    // .round-box;
-    background-color: @syntax-selection-color;
-  }
-  .narrow-result .region {
-    // .round-box;
-    background-color: @syntax-selection-flash-color;
-  }
-
   .line {
     &.narrow-result {
       box-shadow:0 -8px 0 -6px @line-marker inset;


### PR DESCRIPTION
- [x] Ensure
  - [x] dispose subscriptions
    - [x] editor
    - [x] narrowEditor
  - [x] Clear row marker
    - [x] On focus change to associated editor?
- [x] Well manage association between editor and narrowEditor
- [ ] ~~Show empty message on no item?~~
- [x] Protect narrowEditor content by accidental edit?
  - Tried but was super difficult, so added `force-refresh` command to allow use manual-redraw
- [x] Respect currentItem on start moving up/down in narrowEditor.
