### PR TITLE
More protection for narrowEditor in direct-edit

### DIFF
--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -1,9 +1,6 @@
 _ = require 'underscore-plus'
 {Point, CompositeDisposable, Emitter} = require 'atom'
-{
-  saveEditorState
-  padStringLeft
-} = require '../utils'
+{saveEditorState} = require '../utils'
 UI = require '../ui'
 settings = require '../settings'
 Input = null
@@ -115,9 +112,11 @@ class ProviderBase
         item.text
 
   # Unless items didn't have maxLineTextWidth field, detect last line from editor.
-  getLineHeaderForItem: ({text, point, maxLineTextWidth}, editor=@editor) ->
+  getLineHeaderForItem: ({point, maxLineTextWidth}, editor=@editor) ->
     maxLineTextWidth ?= String(editor.getLastBufferRow() + 1).length
-    @indentTextForLineHeader + padStringLeft(String(point.row + 1), maxLineTextWidth) + ': '
+    lineNumberText = String(point.row + 1)
+    padding = " ".repeat(maxLineTextWidth - lineNumberText.length)
+    @indentTextForLineHeader + padding + lineNumberText + ": "
 
   # Direct Edit
   # -------------------------

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -206,9 +206,11 @@ class UI
       return false
 
     if @provider.showLineHeader
-      @narrowEditor.buffer.getLines()[1...].every (line, row) => line.startsWith(@items[row]._lineHeader)
-    else
-      true
+      for line, row in @narrowEditor.buffer.getLines() when (row >= 1)
+        return false unless line.startsWith(@items[row]._lineHeader)
+
+    true
+
 
   observeInputChange: ->
     @narrowEditor.buffer.onDidChange ({newRange, oldRange}) =>

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -187,18 +187,18 @@ class UI
     @moveToPrompt()
     @refresh()
 
-  refreshing: false
   refresh: ->
-    @refreshing = true
     query = @getNarrowQuery()
     words = _.compact(query.split(/\s+/))
     regexps = words.map (word) => @getRegExpForWord(word)
     @grammar.update(regexps)
+    
+    @ignoreChangeOnNarrowEditor = true
     Promise.resolve(@provider.getItems()).then (items) =>
       @clearItemsText()
       @setItems(@provider.filterItems(items, regexps))
       @narrowEditorLastRow = @narrowEditor.getLastBufferRow()
-      @refreshing = false
+      @ignoreChangeOnNarrowEditor = false
 
   ensureNarrowEditorIsValidState: ->
     # Ensure all item have valid line header
@@ -225,6 +225,7 @@ class UI
           # Destroy cursors on prompt
           for selection in @narrowEditor.getSelections() when onPrompt(selection.getBufferRange())
             selection.destroy()
+          # Recover query on prompt
           @setPromptLine(@lastNarrowQuery) if @lastNarrowQuery
         else
           @refresh()

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -130,6 +130,8 @@ class UI
 
   updateRealFile: ->
     return unless @provider.supportDirectEdit
+    return unless @ensureNarrowEditorIsValidState()
+
     states = []
     for lineText, row in @narrowEditor.buffer.getLines()
       continue if row is 0
@@ -190,7 +192,11 @@ class UI
     Promise.resolve(@provider.getItems()).then (items) =>
       @clearItemsText()
       @setItems(@provider.filterItems(items, regexps))
+      @narrowEditorLastRow = @narrowEditor.getLastBufferRow()
       @refreshing = false
+
+  ensureNarrowEditorIsValidState: ->
+    @narrowEditorLastRow is @narrowEditor.getLastBufferRow()
 
   observeInputChange: ->
     @narrowEditor.buffer.onDidChange ({newRange, oldRange}) =>

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -174,7 +174,7 @@ class UI
   getNarrowQuery: ->
     @lastNarrowQuery = @narrowEditor.lineTextForBufferRow(0)
 
-  getRegExpForWord: (word) ->
+  getRegExpForQueryWord: (word) ->
     pattern = _.escapeRegExp(word)
     sensitivity = settings.get('caseSensitivityForNarrowQuery')
     if (sensitivity is 'sensitive') or (sensitivity is 'smartcase' and /[A-Z]/.test(word))
@@ -190,9 +190,9 @@ class UI
   refresh: ->
     query = @getNarrowQuery()
     words = _.compact(query.split(/\s+/))
-    regexps = words.map (word) => @getRegExpForWord(word)
+    regexps = words.map (word) => @getRegExpForQueryWord(word)
     @grammar.update(regexps)
-    
+
     @ignoreChangeOnNarrowEditor = true
     Promise.resolve(@provider.getItems()).then (items) =>
       @clearItemsText()

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -31,10 +31,6 @@ smartScrollToBufferPosition = (editor, point) ->
   center = (onePageDown < target) or (target < onePageUp)
   editor.scrollToBufferPosition(point, {center})
 
-padStringLeft = (string, targetLength) ->
-  padding = " ".repeat(targetLength - string.length)
-  padding + string
-
 # Reloadable registerElement
 registerElement = (name, options) ->
   element = document.createElement(name)
@@ -88,7 +84,6 @@ module.exports = {
   getAdjacentPaneForPane
   openItemInAdjacentPaneForPane
   smartScrollToBufferPosition
-  padStringLeft
   registerElement
   saveEditorState
   requireFrom


### PR DESCRIPTION
Aiming to fix #58


# How did I protect unwanted situation on direct-edit?

## line header mutated

On `updateRealFile`, check each line startsWith lineHeader.
Not perfect I know, but it probably protect 99.9% situation.

## When query text mutation mutating item text directly.

This is happens in multi-cursor situation.
e.g. `ctrl-alt-g`(`find-and-replace:select-all`) to change all word in narrowEditor.
e.g. `c o f` in vim-mode-plus, `change` `occurrence` in `a-function`

In this case, destroy cursor on prompt row(it can be also multiple) and recover query on prompt.

## When item's whole-line deleted/added

On `updateRealFile`, ensure item's total line number not changed when last generated items to narrow.
