### PR TITLE
Simplify vim integration

### DIFF
--- a/keymaps/narrow.cson
+++ b/keymaps/narrow.cson
@@ -36,9 +36,10 @@
   'q': 'core:close'
   'o': 'narrow-ui:confirm-keep-open'
   'r': 'narrow-ui:toggle-auto-preview'
-  'i': 'vim-mode-plus-user:narrow-ui:move-to-prompt'
-  'a': 'vim-mode-plus-user:narrow-ui:move-to-prompt'
+  'i': 'narrow-ui:move-to-prompt'
+  'a': 'narrow-ui:move-to-prompt'
   'I': 'vim-mode-plus:activate-insert-mode'
+  'tab': 'narrow-ui:move-to-prompt-or-selected-item'
 
 'atom-workspace.has-narrow atom-text-editor.vim-mode-plus.normal-mode:not(.has-occurrence)':
   # Can move next/previos from out-side of narrow-editor if workspace has narrow-editor.

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -58,7 +58,8 @@ module.exports =
 
   narrow: (providerName, options) ->
     klass = require("./provider/#{providerName}")
-    new klass(options)
+    editor = atom.workspace.getActiveTextEditor()
+    new klass(editor, options)
 
   deactivate: ->
     @subscriptions?.dispose()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -19,7 +19,7 @@ module.exports =
     @subscriptions.add atom.commands.add 'atom-text-editor',
       # Shared commands
       'narrow:focus': => @getUi()?.toggleFocus()
-      'narrow:focus-prompt': => @getUi()?.toggleFocus(moveToPrompt: true)
+      'narrow:focus-prompt': => @getUi()?.focusPrompt()
       'narrow:close': => @getUi()?.destroy()
       'narrow:next-item': => @getUi()?.nextItem()
       'narrow:previous-item': => @getUi()?.previousItem()
@@ -69,21 +69,7 @@ module.exports =
     atom.workspace.isTextEditor(item) and
       item.element.classList.contains('narrow-editor')
 
-  consumeVim: ({getEditorState, observeVimStates}) ->
-    @subscriptions.add observeVimStates (vimState) =>
-      {editor} = vimState
-      if @isNarrowEditor(editor) and ui = @getUiForEditor(editor)
-        if settings.get('vmpStartInInsertModeForUI')
-          vimState.activate('insert') unless vimState.isMode('insert')
-
-        if settings.get('vmpAutoChangeModeInUI')
-          ui.autoChangeModeForVimState(vimState)
-
-        atom.commands.add ui.editorElement,
-          'vim-mode-plus-user:narrow-ui:move-to-prompt': ->
-            ui.moveToPrompt()
-            vimState.activate('insert') unless vimState.isMode('insert')
-
+  consumeVim: ({getEditorState}) ->
     confirmSearch = -> # return search text
       editor = atom.workspace.getActiveTextEditor()
       vimState = getEditorState(editor)

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -1,6 +1,6 @@
 _ = require 'underscore-plus'
 {Point, CompositeDisposable} = require 'atom'
-{saveEditorState, getAdjacentPaneForPane} = require '../utils'
+{saveEditorState, getAdjacentPaneForPane, isActiveEditor} = require '../utils'
 UI = require '../ui'
 settings = require '../settings'
 Input = null
@@ -32,9 +32,11 @@ class ProviderBase
   getPane: ->
     atom.workspace.paneForItem(@editor)
 
-  constructor: (@options={}) ->
+  isActive: ->
+    isActiveEditor(@editor)
+
+  constructor: (@editor, @options={}) ->
     @subscriptions = new CompositeDisposable
-    @editor = atom.workspace.getActiveTextEditor()
     @editorElement = @editor.element
     @restoreEditorState = saveEditorState(@editor)
 

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -67,12 +67,12 @@ module.exports = new Settings 'narrow',
     default: 'smartcase'
     enum: ['smartcase', 'sensitive', 'insensitive']
     description: "Case sensitivity of your query in narrow-editor"
-  vmpAutoChangeModeInUI:
-    default: true
-    description: "Automatically change mode on narrow-editor, insert-mode(=prompt), normal-mode(=item-area)"
-  vmpStartInInsertModeForUI:
-    default: true
-    description: "Start in insert-mode on initial open"
+  # vmpAutoChangeModeInUI:
+  #   default: true
+  #   description: "Automatically change mode on narrow-editor, insert-mode(=prompt), normal-mode(=item-area)"
+  # vmpStartInInsertModeForUI:
+  #   default: true
+  #   description: "Start in insert-mode on initial open"
 
   # Per providers settings
   # -------------------------

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -67,12 +67,6 @@ module.exports = new Settings 'narrow',
     default: 'smartcase'
     enum: ['smartcase', 'sensitive', 'insensitive']
     description: "Case sensitivity of your query in narrow-editor"
-  # vmpAutoChangeModeInUI:
-  #   default: true
-  #   description: "Automatically change mode on narrow-editor, insert-mode(=prompt), normal-mode(=item-area)"
-  # vmpStartInInsertModeForUI:
-  #   default: true
-  #   description: "Start in insert-mode on initial open"
 
   # Per providers settings
   # -------------------------


### PR DESCRIPTION
#67

Remove config option for vmp integration and get it right by default.
Avoid heavy integration with vmp, instead use `atom.commands.dispatch` since it's work!


- `narrow:focus-prompt`
  - Focus to prompt and start `insert-mode` unless cursor is already at prompt.
  - If cursor is already at prompt, focus back to original pane.
- `narrow:focus`
  - Focus to narrow-editor if it's not focused.
  - If focused, focus back to original pane.

- No longer auto-start `insert-mode` for cursor move within narrow-editor.
- Auto-start-insert-mode is done in following case.
  - When starting narrow, since it start with cursor on prompt.
  - User invoked `narrow:focus-prompt` command.
