### PR TITLE
Make provider re-bindable to different editor

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,7 +1,7 @@
 {CompositeDisposable} = require 'atom'
 settings = require './settings'
 Ui = null
-{isTextEditor, getCurrentWord} = require('./utils')
+{isNarrowEditor, getCurrentWord} = require('./utils')
 
 module.exports =
   config: settings.config
@@ -13,8 +13,7 @@ module.exports =
     settings.removeDeprecated()
 
     @subscriptions.add atom.workspace.onDidStopChangingActivePaneItem (item) =>
-      if @isNarrowEditor(item)
-        @currentNarrowEditor = item
+      @currentNarrowEditor = item if isNarrowEditor(item)
 
     @subscriptions.add atom.commands.add 'atom-text-editor',
       # Shared commands
@@ -64,9 +63,6 @@ module.exports =
   deactivate: ->
     @subscriptions?.dispose()
     {@subscriptions} = {}
-
-  isNarrowEditor: (item) ->
-    isTextEditor(item) and item.element.classList.contains('narrow-editor')
 
   consumeVim: ({getEditorState}) ->
     confirmSearch = -> # return search text

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -35,6 +35,10 @@ class ProviderBase
   initialize: ->
     # to override
 
+  # Event is object contains {newEditor, oldEditor}
+  onBindEditor: (event) ->
+    # to override
+
   checkReady: ->
     Promise.resolve(true)
 
@@ -42,8 +46,10 @@ class ProviderBase
     if @editor isnt editor
       @editorSubscriptions?.dispose()
       @editorSubscriptions = new CompositeDisposable
-      @editor = editor
+      oldEditor = @editor
+      @editor = newEditor = editor
       @restoreEditorState = saveEditorState(@editor)
+      @onBindEditor({oldEditor, newEditor})
 
   getPane: ->
     paneForItem(@editor)
@@ -88,7 +94,9 @@ class ProviderBase
 
     if filePath?
       options = {pending: true}
-      unless pane
+      if pane?
+        pane.activate()
+      else
         options.split = settings.get('directionToOpen')
 
       atom.workspace.open(filePath, options).then (editor) ->

--- a/lib/provider/symbols.coffee
+++ b/lib/provider/symbols.coffee
@@ -15,13 +15,7 @@ class Symbols extends ProviderBase
   showLineHeader: false
   supportCacheItems: false # manage manually
 
-  initialize: ->
-    @subscribe @editor.onDidSave =>
-      @items = null
-
   getItems: ->
-    return @items if @items?
-
     # We show full line text of symbol's line, so just care for which line have symbol.
     filePath = @editor.getPath()
     scopeName = @editor.getGrammar().scopeName

--- a/lib/provider/symbols.coffee
+++ b/lib/provider/symbols.coffee
@@ -14,8 +14,14 @@ class Symbols extends ProviderBase
   boundToEditor: true
   showLineHeader: false
   supportCacheItems: false # manage manually
+  items: null
+
+  onBindEditor: ({newEditor}) ->
+    @items = null
+    @subscribeEditor(newEditor.onDidSave => @items = null)
 
   getItems: ->
+    return @items if @items?
     # We show full line text of symbol's line, so just care for which line have symbol.
     filePath = @editor.getPath()
     scopeName = @editor.getGrammar().scopeName

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -6,6 +6,8 @@ _ = require 'underscore-plus'
   getValidIndexForList
   setBufferRow
   isTextEditor
+  isNarrowEditor
+  paneForItem
 } = require './utils'
 settings = require './settings'
 Grammar = require './grammar'
@@ -101,37 +103,41 @@ class UI
     @promptGutter = new PromptGutter(@editor)
 
     @grammar = new Grammar(@editor, includeHeaderRules: @provider.includeHeaderGrammar)
-    @disposables.add(@registerCommands())
-    @disposables.add(@observeChange())
-    @disposables.add(@observeStopChanging())
-    @disposables.add(@observeCursorMove())
 
-    @disposables.add atom.workspace.onDidStopChangingActivePaneItem (item) =>
-      @syncSubcriptions?.dispose()
-      return if item is @editor
-      @rowMarker?.destroy()
-
-      return unless isTextEditor(item)
-      if @provider.boundToEditor and atom.workspace.paneForItem(item) isnt @getPane()
-        @provider.bindEditor(item)
-        @refresh(force: true).then =>
-          @syncToEditor(item)
-          @setSyncToEditor(item)
-      else
-        if @canSyncToEditor(item)
-          @syncToEditor(item)
-          @setSyncToEditor(item)
+    @disposables.add(
+      @registerCommands()
+      @observeChange()
+      @observeStopChanging()
+      @observeCursorMove()
+      @observeStopChangingActivePaneItem()
+    )
 
     @constructor.register(this)
     @disposables.add new Disposable =>
       @constructor.unregister(this)
 
-  canSyncToEditor: (editor) ->
-    filePath = editor.getPath()
-    if @provider.boundToEditor
-      @provider.editor.getPath() is filePath
-    else
-      @items.some (item) -> item.filePath is filePath
+  observeStopChangingActivePaneItem: ->
+    atom.workspace.onDidStopChangingActivePaneItem (item) =>
+      @syncSubcriptions?.dispose()
+      return if item is @editor
+      @rowMarker?.destroy()
+
+      # Only sync to text-editor which meet following conditions
+      # - Not narrow-editor
+      # - Contained in different pane from narrow-editor is contained.
+      if (not isTextEditor(item)) or isNarrowEditor(item) or (paneForItem(item) is @getPane())
+        return
+
+      if @provider.boundToEditor
+        @provider.bindEditor(item)
+        @refresh(force: true).then =>
+          @syncToEditor(item)
+          @setSyncToEditor(item)
+      else
+        filePath = item.getPath()
+        if @items.some((item) -> item.filePath is filePath)
+          @syncToEditor(item)
+          @setSyncToEditor(item)
 
   start: ->
     activatePaneItemInAdjacentPane(@editor, split: settings.get('directionToOpen'))
@@ -141,7 +147,7 @@ class UI
     @refresh()
 
   getPane: ->
-    atom.workspace.paneForItem(@editor)
+    paneForItem(@editor)
 
   isActive: ->
     isActiveEditor(@editor)
@@ -403,8 +409,8 @@ class UI
     return item # return items[0] as fallback
 
   syncToEditor: (editor) ->
-    return if @isActive() # Prevent UI cursor from being moved while UI is active.
     return if @preventSyncToEditor
+    return if @isActive() # Prevent UI cursor from being moved while UI is active.
     if item = @findClosestItemForEditor(editor)
       @selectItem(item)
       @moveToSelectedItem() unless @isActive()

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -112,8 +112,11 @@ setBufferRow = (cursor, row, options={}) ->
   cursor.setBufferPosition([row, columnAdjusted ? column])
   cursor.goalColumn ?= column
 
-isTextEditor = atom.workspace.isTextEditor
-paneForItem = atom.workspace.paneForItem
+isTextEditor = (item) ->
+  atom.workspace.isTextEditor(item)
+
+paneForItem = (item) ->
+  atom.workspace.paneForItem(item)
 
 isNarrowEditor = (editor) ->
   isTextEditor(editor) and editor.element.classList.contains('narrow-editor')
@@ -131,6 +134,7 @@ module.exports = {
   isActiveEditor
   getValidIndexForList
   setBufferRow
-  isTextEditon
+  isTextEditor
+  isNarrowEditor
   paneForItem
 }

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -113,6 +113,10 @@ setBufferRow = (cursor, row, options={}) ->
   cursor.goalColumn ?= column
 
 isTextEditor = atom.workspace.isTextEditor
+paneForItem = atom.workspace.paneForItem
+
+isNarrowEditor = (editor) ->
+  isTextEditor(editor) and editor.element.classList.contains('narrow-editor')
 
 module.exports = {
   getAdjacentPaneForPane
@@ -127,5 +131,6 @@ module.exports = {
   isActiveEditor
   getValidIndexForList
   setBufferRow
-  isTextEditor
+  isTextEditon
+  paneForItem
 }


### PR DESCRIPTION
Implement idea described in #77


Now all boundToEditor providers are re-bound to **different editor**.  
So usage is greatly enhanced. Keep `narrow:symbols` or `narrow:fold` opend. and changing tab to activate different editor.

Each time you switch tab, symbols or fold items are refreshed and auto sync to current cursor position.

In this usage narrow is getting closer to minimap. But it's narrowable, readable text, clickable and editable(direct-edit-and-save-to-real-file).

## Spec based on current implementation

- Re-bind is happened `onDidStopChangingActivePaneItem`.
- So code are modified to
  - Not store static reference for `@provider.editor` in different component.
    - So `@providerEditor = @provider.editor` in `Ui` code no longer acceptable.
    - Since `provider.editor` can be changed(re-bound) multiple time.

  - Event subscriptions to editor has to be separately managed and disposed on each re-bind timing.
  - Each provider MUST NOT write code as like `@editor` is static(un-changed), this assumption is incorrect.
    - When provider subscribe editor's event(e.g `editor.onDidSave`) to detect manual refresh timing.
      - Use `ProviderBase::onBindEditor`, this is called on each bindToEditor event
      - `{newEditor, oldEditor}` event info is passed to `onBindEditor` so that each provide can use these info.
      - And `@subscribeEditor` to dispose on next rebind.
