### PR TITLE
more intuitive flow for update-real-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Since I want to close manually by `ctrl-g`(Maybe change default in future).
   'cmd-f': 'narrow:focus'
   'cmd-i': 'narrow:focus-prompt' # cmd-i to return to calling editor.
   # Danger, apply change on narrow-editor to real file by `ctrl-cmd-s`.
-  'ctrl-cmd-s': 'narrow-ui:update-real-file'
+  'cmd-s': 'narrow-ui:update-real-file'
 
 # NOTE: following keymap prevent me to type `;`, `[`, `]` in insert-mode.
 # Which is very problematic in direct-edit mode since I can not insert these chars.

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -88,6 +88,7 @@ module.exports = new Settings 'narrow',
     default: 'smartcase'
     enum: ['smartcase', 'sensitive', 'insensitive']
     description: "Case sensitivity of your query in narrow-editor"
+  confirmOnUpdateRealFile: true
 
   # Per providers settings
   # -------------------------


### PR DESCRIPTION
Fix #86


- Overwrite, TextBuffer's `isModified` function to update modified icon on tab(provided by core `tabs` package).
- Now cofirm user before `update-real-file` really update real file.
  - New option `confirmOnUpdateRealFile`(default `true`).
  - If this was set to `false`, no longer ask before `update-real-file`, danger!
- As I wrote in #86, I did experiment to override `core:save` and other simlar approach
  - But I decided that 'its ok to let user just override `cmd-s` to `narrow-ui:update-real-file`'.
  - Overriding `core:save` is too aggressive, so intentionally avoided(or postponed).
