### PR TITLE
[failed attempt] Experiment new-UI, separate query and item area but given up!

### DIFF
--- a/keymaps/narrow.cson
+++ b/keymaps/narrow.cson
@@ -38,13 +38,13 @@
 
 'atom-text-editor.narrow.narrow-editor:not(.read-only)[data-grammar="source narrow"]':
   'ctrl-g': 'narrow-ui:stop-insert'
-  
+
 'atom-text-editor.narrow.narrow-editor.vim-mode-plus:not(.read-only)[data-grammar="source narrow"]':
   'ctrl-g': 'narrow:close'
 
-'atom-text-editor.narrow.narrow-editor.read-only[data-grammar="source narrow"]':
-  'k': 'core:move-up'
-  'j': 'core:move-down'
+# 'atom-text-editor.narrow.narrow-editor.read-only[data-grammar="source narrow"]':
+#   'k': 'core:move-up'
+#   'j': 'core:move-down'
 
 'atom-text-editor.narrow.narrow-editor[data-grammar="source narrow"],
  atom-text-editor.narrow.narrow-editor.vim-mode-plus.insert-mode[data-grammar="source narrow"]':

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,11 +2,11 @@
 settings = require './settings'
 Ui = require './ui'
 
-{isNarrowEditor, getCurrentWord, getVisibleEditors} = require('./utils')
+{isNarrowUi, isNarrowEditor, getCurrentWord, getVisibleEditors} = require('./utils')
 
 module.exports =
   config: settings.config
-  lastFocusedNarrowEditor: null
+  lastFocusedNarrowUi: null
   providers: []
 
   activate: ->
@@ -14,7 +14,7 @@ module.exports =
     settings.removeDeprecated()
 
     @subscriptions.add atom.workspace.onDidStopChangingActivePaneItem (item) =>
-      @lastFocusedNarrowEditor = item if isNarrowEditor(item)
+      @lastFocusedNarrowUi = item if isNarrowUi(item)
 
     @subscriptions.add atom.commands.add 'atom-text-editor',
       # Shared commands
@@ -47,13 +47,15 @@ module.exports =
       'narrow:atom-scan-by-current-word': => @narrow('atom-scan', currentWord: true)
 
   getUi: ->
-    if ui = Ui.get(@lastFocusedNarrowEditor)
+    if ui = Ui.get(@lastFocusedNarrowUi)
       ui
     else
-      for editor in getVisibleEditors() when isNarrowEditor(editor)
-        return Ui.get(editor)
-      for editor in atom.workspace.getTextEditors() when isNarrowEditor(editor)
-        return Ui.get(editor)
+      null
+      # for editor.
+      # for editor in getVisibleEditors() when isNarrowEditor(editor)
+      #   return Ui.get(editor)
+      # for editor in atom.workspace.getTextEditors() when isNarrowEditor(editor)
+      #   return Ui.get(editor)
 
   # Return currently selected text or word under cursor.
   getCurrentWord: ->

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -121,6 +121,9 @@ paneForItem = (item) ->
 isNarrowEditor = (editor) ->
   isTextEditor(editor) and editor.element.classList.contains('narrow-editor')
 
+isNarrowUi = (item) ->
+  item?.classList?.contains('narrow-ui')
+
 getVisibleEditors = ->
   atom.workspace.getPanes()
     .map (pane) -> pane.getActiveEditor()
@@ -141,6 +144,7 @@ module.exports = {
   setBufferRow
   isTextEditor
   isNarrowEditor
+  isNarrowUi
   paneForItem
   getVisibleEditors
 }

--- a/styles/narrow.less
+++ b/styles/narrow.less
@@ -56,3 +56,25 @@ atom-text-editor.narrow-editor {
     }
   }
 }
+
+.narrow-ui {
+  padding: @component-padding / 2;
+  background: @pane-item-background-color;
+  color: @text-color;
+
+  atom-text-editor {
+    background: @syntax-background-color;
+    // margin:
+    border: 0px solid darken(@syntax-background-color, 10%);
+    margin: 2px 0;
+  }
+  atom-text-editor[mini] {
+    border: none;
+    background: @input-background-color;
+
+    &.is-focused {
+      background: @input-background-color;
+      box-shadow: none;
+    }
+  }
+}


### PR DESCRIPTION
Tried to evaluate #78

Failed, blockDecoration approach(worth to retry, haven't investigated further)
I mainly evaluated following approach

- query-input-editor: use mini-editor
- item-area-editor: use normal text-editor
- view: container `div` element holding query-input-editor and item-area-editor, view is used as paneItem(activated in pane)

# Why failed?

Embedded text-editor is ignored by Atom-core API.  
**I want item-rendering text-editor is exactly same text-editor user normally interacting**.  

- Good: No mess by separating query editor and item rendering area and also good looking(surface).
  - The new look(UI) was, good
  - code was separated to query and item area
    - So no longer need dirty locking(`@ignoreCursorMove`, `@ignoreChange` etc).
    - This was really good for maintainability.

- Bad: embedded text-editor is ignored by Atom-core API.
  - Atom's core API not take in account for embedded text-editor.
  - `atom.workspace.observeTextEditors`, `atom.workspace.getTextEditors` just ignore item-area-editor. since it's NOT directly added as paneItem.
  - But I want this item area directly-editable with `vim-mode-plus` enabled editor.
    - Also want to use normal cmd-f(`find-and-replace`), or my `quick-highlight` package. but these package can't handle the text-editor which is not informed by those API.
    - I can enable vim-mode-plus manually on these editor, but what about other package? It's impossible to manually support each one by one.
    - I want make item-area exactly behave as **normal text-editor**. So by only this reason, I decided to stop experiment/evaluation.


![narrow-failed-ui-embed-mini-and-normal-editor](https://cloud.githubusercontent.com/assets/155205/22531145/93f1cc6e-e922-11e6-9417-42a669b34cb9.gif)
