### PR TITLE
exclude particular file manually

### DIFF
--- a/keymaps/narrow.cson
+++ b/keymaps/narrow.cson
@@ -36,6 +36,10 @@
   'i': 'narrow-ui:move-to-prompt'
   'a': 'narrow-ui:move-to-prompt'
   'I': 'narrow-ui:start-insert'
+  'n': 'narrow-ui:move-to-next-file-item'
+  'p': 'narrow-ui:move-to-previous-file-item'
+  'backspace': 'narrow-ui:exclude-file'
+  'ctrl-backspace': 'narrow-ui:clear-excluded-files'
 
 'atom-text-editor.narrow.narrow-editor:not(.read-only)[data-grammar="source narrow"]':
   'escape': 'narrow-ui:stop-insert'

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -341,12 +341,10 @@ class UI
 
   excludeFile: ->
     return if @provider.boundToEditor
-
-    if item = @getSelectedItem()
-      {filePath} = item
-      @excludedFiles.push(filePath) unless filePath in @excludedFiles
+    return unless selectedItem = @getSelectedItem()
+    unless selectedItem.filePath in @excludedFiles
+      @excludedFiles.push(filePath)
       nextFileItem = @findDifferentFileItem('next')
-
       @refresh().then =>
         if nextFileItem
           @selectItem(nextFileItem)

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -82,6 +82,7 @@ class UI
       'narrow-ui:toggle-auto-preview': => @toggleAutoPreview()
       'narrow-ui:move-to-prompt-or-selected-item': => @moveToPromptOrSelectedItem()
       'narrow-ui:move-to-prompt': => @moveToPrompt()
+      'narrow-ui:exclude-file': => @excludeFile()
       'narrow-ui:start-insert': => @setReadOnly(false)
       'narrow-ui:stop-insert': => @setReadOnly(true)
       'core:move-up': (event) => @moveUpOrDown(event, 'previous')

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -343,20 +343,27 @@ class UI
     return if @provider.boundToEditor
     return unless selectedItem = @getSelectedItem()
     unless selectedItem.filePath in @excludedFiles
-      @excludedFiles.push(filePath)
+      @excludedFiles.push(selectedItem.filePath)
       nextFileItem = @findDifferentFileItem('next')
+      {column} = @editor.getCursorBufferPosition()
       @refresh().then =>
         if nextFileItem
           @selectItem(nextFileItem)
           @moveToSelectedItem()
+          {row} = @editor.getCursorBufferPosition()
+          @editor.setCursorBufferPosition([row, column])
 
   clearExcludedFiles: ->
+    return if @excludedFiles.length is 0
     @excludedFiles = []
     selectedItem = @getSelectedItem()
+    {column} = @editor.getCursorBufferPosition()
     @refresh().then =>
       if selectedItem
         @selectItem(selectedItem)
         @moveToSelectedItem()
+        {row} = @editor.getCursorBufferPosition()
+        @editor.setCursorBufferPosition([row, column])
 
   refresh: ({force}={}) ->
     if force

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -376,7 +376,6 @@ class UI
         @cachedItems = items
       items = @provider.filterItems(items, filterSpec)
 
-      console.log 'ex', @excludedFiles
       if not @provider.boundToEditor and @excludedFiles.length
         items = items.filter ({filePath}) => filePath not in @excludedFiles
 


### PR DESCRIPTION
Aiming to fix #92

:tada: Greatly improve usability!

# New commands and keymap

keymap is available on `narrow-editor` with scoped `vim-mode-plus.normal-mode` or `read-only` mode.

- `narrow-ui:exclude-file`: `backspace`, Exclude currently selected file from result.(no effect in boundToEditor provider)
- `narrow-ui:clear-excluded-files`: `ctrl-backspace`, Clear exclude-file list. and refresh
- `narrow-ui:move-to-next-file-item`: `n`, Move to first-item of next-file.
- `narrow-ui:move-to-previous-file-item`: `p` Move to last-item of previous-file.
