### PR TITLE
search-file and atom-scan-file

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -42,12 +42,17 @@ module.exports =
       # search family
       'narrow:search': => @narrow('search')
       'narrow:search-by-current-word': => @narrow('search', currentWord: true)
-
+      
       'narrow:search-current-project': => @narrow('search', currentProject: true)
       'narrow:search-current-project-by-current-word': => @narrow('search', currentProject: true, currentWord: true)
 
+      'narrow:search-file': => @narrow('search', currentFile: true)
+      'narrow:search-file-by-current-word': => @narrow('search', currentWord: true, currentFile: true)
+
       'narrow:atom-scan': => @narrow('atom-scan')
       'narrow:atom-scan-by-current-word': => @narrow('atom-scan', currentWord: true)
+      'narrow:atom-scan-file': => @narrow('atom-scan', currentFile: true)
+      'narrow:atom-scan-file-by-current-word': => @narrow('atom-scan', currentWord: true, currentFile: true)
 
   getUi: ({skipProtected}={}) ->
     if ui = Ui.get(@lastFocusedNarrowEditor)

--- a/lib/provider/search-base.coffee
+++ b/lib/provider/search-base.coffee
@@ -21,6 +21,9 @@ class SearchBase extends ProviderBase
   regExpForSearchTerm: null
 
   checkReady: ->
+    if @options.currentFile
+      @options.filePath = @editor.getPath()
+
     if @options.currentWord
       {word, boundary} = getCurrentWordAndBoundary(@editor)
       @options.wordOnly = boundary
@@ -64,6 +67,21 @@ class SearchBase extends ProviderBase
     else
       searchTerm = source
     @ui.grammar.setSearchTerm(searchTerm)
+
+  filterItems: (items, filterSpec) ->
+    items = super
+    normalItems = _.reject(items, (item) -> item.skip)
+    filePaths = _.uniq(_.pluck(normalItems, "filePath"))
+    projectNames = _.uniq(_.pluck(normalItems, "projectName"))
+
+    items.filter (item) ->
+      if item.header?
+        if item.projectHeader?
+          item.projectName in projectNames
+        else
+          item.filePath in filePaths
+      else
+        true
 
   # Highlight items
   # -------------------------


### PR DESCRIPTION
# Changes

### New commands

- `narrow:search-file`
- `narrow:search-file-by-current-word`
- `narrow:atom-scan-file`
- `narrow:atom-scan-file-by-current-word`

### View improve for `atom-scan`

- Now atom-scan display project-header and file-header relativised.
