### PR TITLE
narrow:scan as better narrow:line

### DIFF
--- a/keymaps/narrow.cson
+++ b/keymaps/narrow.cson
@@ -27,6 +27,11 @@
   'cmd-]': 'narrow-ui:fold:increase-fold-level'
   'cmd-[': 'narrow-ui:fold:decrease-fold-level'
 
+# narrow-editor.scan
+# -------------------------
+'atom-text-editor.narrow.narrow-editor.scan[data-grammar="source narrow"]':
+  'ctrl-cmd-t': 'narrow:scan:toggle-scan-word'
+
 'atom-text-editor.narrow.narrow-editor.read-only[data-grammar="source narrow"],
  atom-text-editor.narrow.narrow-editor.vim-mode-plus.normal-mode[data-grammar="source narrow"]':
   'enter': 'core:confirm'

--- a/lib/highlighter.coffee
+++ b/lib/highlighter.coffee
@@ -1,0 +1,87 @@
+{CompositeDisposable} = require 'atom'
+_ = require 'underscore-plus'
+{
+  getVisibleEditors
+  isTextEditor
+  isNarrowEditor
+  updateDecoration
+} = require './utils'
+
+module.exports =
+class Highlighter
+  regexp: null
+
+  constructor: (@provider) ->
+    @ui = @provider.ui
+    @markerLayerByEditor = new Map()
+    @decorationByItem = new Map()
+    @subscriptions = new CompositeDisposable
+    @subscriptions.add(
+      @observeUiStopRefreshing()
+      @observeUiChangeSelectedItem()
+      @observeUiPreview()
+      @observeStopChangingActivePaneItem()
+    )
+
+  setRegExp: (@regexp) ->
+
+  destroy: ->
+    @clearHighlight()
+    @subscriptions.dispose()
+
+  # Highlight items
+  # -------------------------
+  clearHighlight: ->
+    @markerLayerByEditor.forEach (markerLayer) ->
+      marker.destroy() for marker in markerLayer.getMarkers()
+    @markerLayerByEditor.clear()
+    @decorationByItem.clear()
+
+  decorationOptions = {type: 'highlight', class: 'narrow-search-match'}
+  highlightEditor: (editor) ->
+    return unless @regexp
+    return if @provider.boundToEditor and editor isnt @provider.editor
+    # Get items shown on narrow-editor and also matching editor's filePath
+    if @provider.boundToEditor
+      items = @ui.getNormalItems()
+    else
+      items = @ui.getNormalItemsForFilePath(editor.getPath())
+    return unless items.length
+
+    @markerLayerByEditor.set(editor, markerLayer = editor.addMarkerLayer())
+    editor.scan @regexp, ({range}) =>
+      if item = _.detect(items, ({point}) -> point.isEqual(range.start))
+        marker = markerLayer.markBufferRange(range, invalidate: 'inside')
+        decoration = editor.decorateMarker(marker, decorationOptions)
+        @decorationByItem.set(item, decoration)
+
+  updateCurrentHighlight: ->
+    if decoration = @decorationByItem.get(@ui.getPreviouslySelectedItem())
+      updateDecoration(decoration, (cssClass) -> cssClass.replace(' current', ''))
+
+    if decoration = @decorationByItem.get(@ui.getSelectedItem())
+      updateDecoration(decoration, (cssClass) -> cssClass.replace(' current', '') + ' current')
+
+  observeUiStopRefreshing: ->
+    @ui.onDidStopRefreshing =>
+      @clearHighlight()
+      for editor in getVisibleEditors() when not isNarrowEditor(editor)
+        @highlightEditor(editor)
+      @updateCurrentHighlight()
+
+  observeUiPreview: ->
+    @ui.onDidPreview ({editor}) =>
+      unless @markerLayerByEditor.has(editor)
+        @highlightEditor(editor)
+        @updateCurrentHighlight()
+
+  observeStopChangingActivePaneItem: ->
+    atom.workspace.onDidStopChangingActivePaneItem (item) =>
+      if isTextEditor(item) and not isNarrowEditor(item)
+        unless @markerLayerByEditor.has(item)
+          @highlightEditor(item)
+          @updateCurrentHighlight()
+
+  observeUiChangeSelectedItem: ->
+    @ui.onDidChangeSelectedItem =>
+      @updateCurrentHighlight()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -49,13 +49,8 @@ module.exports =
       'narrow:search-current-project': => @narrow('search', currentProject: true)
       'narrow:search-current-project-by-current-word': => @narrow('search', currentProject: true, currentWord: true)
 
-      'narrow:search-file': => @narrow('search', currentFile: true)
-      'narrow:search-file-by-current-word': => @narrow('search', currentWord: true, currentFile: true)
-
       'narrow:atom-scan': => @narrow('atom-scan')
       'narrow:atom-scan-by-current-word': => @narrow('atom-scan', currentWord: true)
-      'narrow:atom-scan-file': => @narrow('atom-scan', currentFile: true)
-      'narrow:atom-scan-file-by-current-word': => @narrow('atom-scan', currentWord: true, currentFile: true)
 
   getUi: ({skipProtected}={}) ->
     if ui = Ui.get(@lastFocusedNarrowEditor)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -39,10 +39,13 @@ module.exports =
       'narrow:lines-by-current-word': => @narrow('lines', uiInput: @getCurrentWord())
       'narrow:fold-by-current-word': => @narrow('fold', uiInput: @getCurrentWord())
 
+      'narrow:scan': => @narrow('scan')
+      'narrow:scan-by-current-word': => @narrow('scan', uiInput: @getCurrentWord())
+
       # search family
       'narrow:search': => @narrow('search')
       'narrow:search-by-current-word': => @narrow('search', currentWord: true)
-      
+
       'narrow:search-current-project': => @narrow('search', currentProject: true)
       'narrow:search-current-project-by-current-word': => @narrow('search', currentProject: true, currentWord: true)
 

--- a/lib/provider/atom-scan.coffee
+++ b/lib/provider/atom-scan.coffee
@@ -7,6 +7,7 @@ module.exports =
 class AtomScan extends SearchBase
   supportCacheItems: true
 
+  # Not used but keep it since I'm planning to introduce per file refresh on modification
   scanFile: (regexp, filePath) ->
     items = []
     atom.workspace.open(filePath, activateItem: false).then (editor) ->
@@ -51,7 +52,4 @@ class AtomScan extends SearchBase
       items
 
   getItems: ->
-    if @options.filePath
-      @scanFile(@regExpForSearchTerm, @options.filePath)
-    else
-      @scanWorkspace(@regExpForSearchTerm)
+    @scanWorkspace(@regExpForSearchTerm)

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -177,3 +177,11 @@ class ProviderBase
 
   getFirstCharacterPointOfRow: (row) ->
     getFirstCharacterPositionForBufferRow(@editor, row)
+
+  setGrammarSearchTerm: (regexp) ->
+    source = regexp.source
+    if regexp.ignoreCase
+      searchTerm = "(?i:#{source})"
+    else
+      searchTerm = source
+    @ui.grammar.setSearchTerm(searchTerm)

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -21,6 +21,7 @@ class ProviderBase
   ignoreSideMovementOnSyncToEditor: true
   showLineHeader: false
   showColumnOnLineHeader: false
+  updateGrammarOnQueryChange: true
 
   supportDirectEdit: false
   supportCacheItems: false

--- a/lib/provider/scan.coffee
+++ b/lib/provider/scan.coffee
@@ -16,7 +16,12 @@ class Scan extends ProviderBase
   updateGrammarOnQueryChange: false # for manual update
 
   initialize: ->
-    @scanWord = @getConfig('scanWord')
+    if @options.uiInput? and @editor.getSelectedBufferRange().isEmpty()
+      # scan by word-boundry if scan-by-current-word is invoked with empty selection.
+      @scanWord = true
+    else
+      @scanWord = @getConfig('scanWord')
+
     @highlighter = new Highlighter(this)
     @subscriptions.add new Disposable =>
       @highlighter.destroy()

--- a/lib/provider/scan.coffee
+++ b/lib/provider/scan.coffee
@@ -16,9 +16,13 @@ class Scan extends ProviderBase
   updateGrammarOnQueryChange: false # for manual update
 
   initialize: ->
+    @scanWord = @getConfig('scanWord')
     @highlighter = new Highlighter(this)
     @subscriptions.add new Disposable =>
       @highlighter.destroy()
+
+    atom.commands.add @ui.editorElement,
+      'narrow:scan:toggle-scan-word': => @toggleScanWord()
 
   scanEditor: (regexp) ->
     items = []
@@ -29,10 +33,17 @@ class Scan extends ProviderBase
       })
     items
 
+  toggleScanWord: ->
+    @scanWord = not @scanWord
+    @ui.refresh(force: true)
+
   getItems: ->
     {include} = @ui.getFilterSpec()
     if include.length
       regexp = setGlobalFlagForRegExp(include.shift())
+      if @scanWord
+        regexp = new RegExp("\\b#{regexp.source}\\b", regexp.flags)
+
       @highlighter.setRegExp(regexp)
       @setGrammarSearchTerm(regexp)
       @scanEditor(regexp)

--- a/lib/provider/scan.coffee
+++ b/lib/provider/scan.coffee
@@ -1,0 +1,53 @@
+path = require 'path'
+_ = require 'underscore-plus'
+{Point} = require 'atom'
+{setGlobalFlagForRegExp} = require '../utils'
+ProviderBase = require './provider-base'
+
+module.exports =
+class Scan extends ProviderBase
+  boundToEditor: true
+  supportCacheItems: false
+  supportDirectEdit: true
+  showLineHeader: true
+  showColumnOnLineHeader: true
+  ignoreSideMovementOnSyncToEditor: false
+  updateGrammarOnQueryChange: false
+
+  scanEditor: (regexp) ->
+    regexp = setGlobalFlagForRegExp(regexp)
+    items = []
+    @editor.scan regexp, ({range}) =>
+      items.push({
+        text: @editor.lineTextForBufferRow(range.start.row)
+        point: range.start
+      })
+    items
+
+  getItems: ->
+    {include} = @ui.getFilterSpec()
+    if include.length
+      regexp = include.shift()
+      source = regexp.source
+      if regexp.ignoreCase
+        searchTerm = "(?i:#{source})"
+      else
+        searchTerm = source
+      @ui.grammar.setSearchTerm(searchTerm)
+      @scanEditor(regexp)
+    else
+      []
+
+  filterItems: (items, {include, exclude}) ->
+    if include.length is 0
+      return items
+
+    include.shift()
+    @ui.grammar.update(include)
+    for regexp in exclude
+      items = items.filter (item) -> not regexp.test(item.text)
+
+    for regexp in include
+      items = items.filter (item) -> regexp.test(item.text)
+
+    items

--- a/lib/provider/search-base.coffee
+++ b/lib/provider/search-base.coffee
@@ -16,9 +16,6 @@ class SearchBase extends ProviderBase
   regExpForSearchTerm: null
 
   checkReady: ->
-    if @options.currentFile
-      @options.filePath = @editor.getPath()
-
     if @options.currentWord
       {word, boundary} = getCurrentWordAndBoundary(@editor)
       @options.wordOnly = boundary

--- a/lib/provider/search-base.coffee
+++ b/lib/provider/search-base.coffee
@@ -1,14 +1,9 @@
 _ = require 'underscore-plus'
 
 ProviderBase = require './provider-base'
+Highlighter = require '../highlighter'
 {Disposable} = require 'atom'
-{
-  getCurrentWordAndBoundary
-  getVisibleEditors
-  isTextEditor
-  isNarrowEditor
-  updateDecoration
-} = require '../utils'
+{getCurrentWordAndBoundary} = require '../utils'
 
 module.exports =
 class SearchBase extends ProviderBase
@@ -49,24 +44,13 @@ class SearchBase extends ProviderBase
       new RegExp(source, 'gi')
 
   initialize: ->
-    @markerLayerByEditor = new Map()
-    @decorationByItem = new Map()
-    clearHighlight = new Disposable => @clearHighlight()
-    @subscriptions.add(
-      clearHighlight
-      @observeUiStopRefreshing()
-      @observeUiChangeSelectedItem()
-      @observeUiPreview()
-      @observeStopChangingActivePaneItem()
-    )
+    @highlighter = new Highlighter(this)
+    @subscriptions.add new Disposable =>
+      @highlighter.destroy()
 
     @regExpForSearchTerm = @getRegExpForSearchTerm()
-    source = @regExpForSearchTerm.source
-    if @regExpForSearchTerm.ignoreCase
-      searchTerm = "(?i:#{source})"
-    else
-      searchTerm = source
-    @ui.grammar.setSearchTerm(searchTerm)
+    @highlighter.setRegExp(@regExpForSearchTerm)
+    @setGrammarSearchTerm(@regExpForSearchTerm)
 
   filterItems: (items, filterSpec) ->
     items = super
@@ -82,54 +66,3 @@ class SearchBase extends ProviderBase
           item.filePath in filePaths
       else
         true
-
-  # Highlight items
-  # -------------------------
-  clearHighlight: ->
-    @markerLayerByEditor.forEach (markerLayer) ->
-      marker.destroy() for marker in markerLayer.getMarkers()
-    @markerLayerByEditor.clear()
-    @decorationByItem.clear()
-
-  decorationOptions = {type: 'highlight', class: 'narrow-search-match'}
-  highlightEditor: (editor) ->
-    # Get items shown on narrow-editor and also matching editor's filePath
-    items = @ui.getNormalItemsForFilePath(editor.getPath())
-    return unless items.length
-
-    @markerLayerByEditor.set(editor, markerLayer = editor.addMarkerLayer())
-    editor.scan @regExpForSearchTerm, ({range}) =>
-      if item = _.detect(items, ({point}) -> point.isEqual(range.start))
-        marker = markerLayer.markBufferRange(range, invalidate: 'inside')
-        decoration = editor.decorateMarker(marker, decorationOptions)
-        @decorationByItem.set(item, decoration)
-
-  updateCurrentHighlight: ->
-    if decoration = @decorationByItem.get(@ui.getPreviouslySelectedItem())
-      updateDecoration(decoration, (cssClass) -> cssClass.replace(' current', ''))
-
-    if decoration = @decorationByItem.get(@ui.getSelectedItem())
-      updateDecoration(decoration, (cssClass) -> cssClass.replace(' current', '') + ' current')
-
-  observeUiStopRefreshing: ->
-    @ui.onDidStopRefreshing =>
-      @clearHighlight()
-      @highlightEditor(editor) for editor in getVisibleEditors()
-      @updateCurrentHighlight()
-
-  observeUiPreview: ->
-    @ui.onDidPreview ({editor}) =>
-      unless @markerLayerByEditor.has(editor)
-        @highlightEditor(editor)
-        @updateCurrentHighlight()
-
-  observeStopChangingActivePaneItem: ->
-    atom.workspace.onDidStopChangingActivePaneItem (item) =>
-      if isTextEditor(item) and not isNarrowEditor(item)
-        unless @markerLayerByEditor.has(item)
-          @highlightEditor(item)
-          @updateCurrentHighlight()
-
-  observeUiChangeSelectedItem: ->
-    @ui.onDidChangeSelectedItem =>
-      @updateCurrentHighlight()

--- a/lib/provider/search.coffee
+++ b/lib/provider/search.coffee
@@ -41,6 +41,7 @@ getOutputterForProject = (project, items) ->
 
       items.push({point, text, filePath, projectName})
 
+# Not used but keep it since I'm planning to introduce per file refresh on modification
 getOutputterForFile = (items) ->
   (data) ->
     for line in data.split("\n") when parsed = parseLine(line)
@@ -66,11 +67,8 @@ class Search extends SearchBase
 
   getItems: ->
     searchPromises = []
-    if @options.filePath?
-      searchPromises.push(@search(@regExpForSearchTerm, {filePath: @options.filePath}))
-    else
-      for project in @options.projects ? atom.project.getPaths()
-        searchPromises.push(@search(@regExpForSearchTerm, {project}))
+    for project in @options.projects ? atom.project.getPaths()
+      searchPromises.push(@search(@regExpForSearchTerm, {project}))
 
     Promise.all(searchPromises).then (values) ->
       _.flatten(values)

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -106,7 +106,16 @@ module.exports = new Settings 'narrow',
   Fold: newProviderConfig()
   GitDiff: newProviderConfig()
   Lines: newProviderConfig()
-  Scan: newProviderConfig()
+  Scan: newProviderConfig(
+    scanWord:
+      default: false
+      description: """
+      This provider is exceptional since it use first query as scan term.<br>
+      This option control default word-boundry scan behavior.<br>
+      You can toggle value per narrow-editor via `narrow:scan:toggle-scan-word`( `ctrl-cmd-t` )<br>
+      """
+  )
+
   Linter: newProviderConfig()
   Search: newProviderConfig(
     caseSensitivityForSearchTerm:

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -106,6 +106,7 @@ module.exports = new Settings 'narrow',
   Fold: newProviderConfig()
   GitDiff: newProviderConfig()
   Lines: newProviderConfig()
+  Scan: newProviderConfig()
   Linter: newProviderConfig()
   Search: newProviderConfig(
     caseSensitivityForSearchTerm:

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -433,6 +433,12 @@ class UI
       if @isActive()
         @selectItemForRow(@findRowForNormalItem(0, 'next'))
       @setModifiedState(false)
+      unless @hasItems()
+        @selectedItem = null
+        @previouslySelectedItem = null
+        @rowMarker?.destroy()
+        @rowMarker = null
+
       @emitDidRefresh()
       @emitDidStopRefreshing()
 
@@ -634,6 +640,11 @@ class UI
   preview: ->
     @preventSyncToEditor = true
     item = @getSelectedItem()
+    unless item
+      @preventSyncToEditor = false
+      @rowMarker?.destroy()
+      return
+
     @provider.openFileForItem(item).then (editor) =>
       editor.scrollToBufferPosition(item.point, center: true)
       @setRowMarker(editor, item.point)
@@ -739,6 +750,9 @@ class UI
   selectItem: (item) ->
     if (row = @getRowForItem(item)) >= 0
       @selectItemForRow(row)
+
+  hasItems: ->
+    @items.length > 1 # ignore prompt placeholder item
 
   selectItemForRow: (row) ->
     item = @items[row]

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -400,6 +400,9 @@ class UI
         {row} = @editor.getCursorBufferPosition()
         @editor.setCursorBufferPosition([row, column])
 
+  getFilterSpec: ->
+    getFilterSpecForQuery(@getQuery())
+
   refresh: ({force}={}) ->
     if force
       @cachedItems = null
@@ -414,9 +417,10 @@ class UI
           @cachedItems = items
         items
 
-    filterSpec = getFilterSpecForQuery(@getQuery())
-    # No need to highlight excluded items
-    @grammar.update(filterSpec.include)
+    filterSpec = @getFilterSpec()
+    if @provider.updateGrammarOnQueryChange
+      # No need to highlight excluded items
+      @grammar.update(filterSpec.include)
 
     promiseForItems.then (items) =>
       items = @provider.filterItems(items, filterSpec)

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -801,6 +801,9 @@ class UI
       item._lineHeader = @getLineHeaderForItem(item.point, maxLineWidth, maxColumnWidth)
     items
 
+  getNormalItems: ->
+    @items.filter (item) -> (not item.skip)
+
   getNormalItemsForFilePath: (filePath) ->
     @items.filter (item) ->
       (not item.skip) and (item.filePath is filePath)

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -149,6 +149,12 @@ updateDecoration = (decoration, fn) ->
   klass = decoration.getProperties().class
   decoration.setProperties(type: type, class: fn(klass))
 
+setGlobalFlagForRegExp = (regexp) ->
+  if regexp.global
+    regexp
+  else
+    new RegExp(regexp.source, regexp.flags + 'g')
+
 module.exports = {
   getAdjacentPaneForPane
   activatePaneItemInAdjacentPane
@@ -169,4 +175,5 @@ module.exports = {
   getVisibleEditors
   getFirstCharacterPositionForBufferRow
   updateDecoration
+  setGlobalFlagForRegExp
 }


### PR DESCRIPTION
Fixes #111

## Spec

`narrow:scan` have some special, exceptional characteristics for how it react narrow queries.

- Use first include narrow query as scan term.
- Rest of include and exclude queries are treated as normal filter query.
- To make this exceptional query handling obvious by eye, use different syntax grammar highlight for first query(= scan term).
- it start with empty items, since no query means no scan-term provided.
