### PR TITLE
show search option info on ui and toggle options by click

### DIFF
--- a/lib/grammar.coffee
+++ b/lib/grammar.coffee
@@ -58,7 +58,7 @@ class Grammar
       @searchTerm = "(?i:#{regexp.source})"
     else
       @searchTerm = source
-    @emitDidChangeSearchTerm(source)
+    @emitDidChangeSearchTerm(regexp)
 
   getRule: ->
     rule =

--- a/lib/grammar.coffee
+++ b/lib/grammar.coffee
@@ -1,3 +1,5 @@
+{Emitter} = require 'atom'
+
 path = require 'path'
 _ = require 'underscore-plus'
 
@@ -23,7 +25,11 @@ class Grammar
   filePath: path.join(__dirname, 'grammar', 'narrow.cson')
   scopeName: 'source.narrow'
 
+  onDidChangeSearchTerm: (fn) -> @emitter.on('did-change-search-term', fn)
+  emitDidChangeSearchTerm: (searchTerm) -> @emitter.emit('did-change-search-term', searchTerm)
+
   constructor: (@editor, {@includeHeaderRules}={}) ->
+    @emitter = new Emitter
 
   activate: (rule = @getRule()) ->
     atom.grammars.removeGrammarForScopeName(@scopeName)
@@ -46,7 +52,13 @@ class Grammar
       )
     @activate(rule)
 
-  setSearchTerm: (@searchTerm) ->
+  setSearchTerm: (regexp) ->
+    source = regexp?.source ? ''
+    if regexp?.ignoreCase
+      @searchTerm = "(?i:#{regexp.source})"
+    else
+      @searchTerm = source
+    @emitDidChangeSearchTerm(source)
 
   getRule: ->
     rule =

--- a/lib/provider-information.coffee
+++ b/lib/provider-information.coffee
@@ -26,15 +26,13 @@ class ProviderInformation
     loadingElement = @container.getElementsByClassName('loading')[0]
     itemCountElement = @container.getElementsByClassName('item-counter')[0]
     @searchTermElement = @container.getElementsByClassName('search-term')[0]
-    willRefreshClassName = 'loading loading-spinner-tiny inline-block'
-    didRefreshClassName = 'ready icon icon-eye-watch'
+    willRefreshClassName = 'search-progress loading loading-spinner-tiny inline-block'
+    didRefreshClassName = 'search-progress ready icon icon-eye-watch'
     @ui.onWillRefresh ->
       loadingElement.className = willRefreshClassName
     @ui.onDidRefresh =>
       itemCountElement.textContent = @ui.getNormalItems().length
       loadingElement.className = didRefreshClassName
-
-    # @ui.onDidStopRefreshing ->
 
     @ui.grammar.onDidChangeSearchTerm (source) =>
       @searchTermElement.textContent = source

--- a/lib/provider-information.coffee
+++ b/lib/provider-information.coffee
@@ -7,8 +7,6 @@ module.exports =
 class ProviderInformation
   constructor: (@ui) ->
     {@editor, @provider} = @ui
-    @disposables = new CompositeDisposable
-
     @container = document.createElement('div')
     @container.className = 'narrow-provider-information'
     @container.innerHTML = """
@@ -44,7 +42,7 @@ class ProviderInformation
     @wholeWordButton.addEventListener('click', @toggleSearchWholeWord)
 
   destroy: ->
-    @disposables.destroy()
+    @toolTipDisposables?.dispose()
     @marker?.destroy()
 
   # Can be called multiple times
@@ -64,12 +62,15 @@ class ProviderInformation
   toggleSearchWholeWord: => @ui.toggleSearchWholeWord()
 
   activateToolTips: ->
-    @disposables.add atom.tooltips.add @wholeWordButton,
+    @toolTipDisposables?.dispose()
+    @toolTipDisposables = disposables = new CompositeDisposable
+
+    disposables.add atom.tooltips.add @wholeWordButton,
       title: "wholeWord"
       keyBindingCommand: 'narrow-ui:toggle-search-whole-word'
       keyBindingTarget: @ui.editorElement
 
-    @disposables.add atom.tooltips.add @ignoreCaseButton,
+    disposables.add atom.tooltips.add @ignoreCaseButton,
       title: "ignoreCase"
       keyBindingCommand: 'narrow-ui:toggle-search-ignore-case'
       keyBindingTarget: @ui.editorElement

--- a/lib/provider-information.coffee
+++ b/lib/provider-information.coffee
@@ -13,12 +13,12 @@ class ProviderInformation
     @container.innerHTML = """
     <div class='block'>
       <span class='loading loading-spinner-tiny inline-block'></span>
-      <span class='provider-name status-added'>#{@provider.getDashName()}</span>
+      <span class='provider-name'>#{@provider.getDashName()}</span>
+      <span class='item-counter'>0</span>
       <div class='btn-group btn-group-xs'>
         <button class='btn'>Aa</button>
         <button class='btn'>\\b</button>
       </div>
-      <span class='item-counter'>0</span>
       <span class='search-term'></span>
     </div>
     """

--- a/lib/provider-information.coffee
+++ b/lib/provider-information.coffee
@@ -34,8 +34,8 @@ class ProviderInformation
       itemCountElement.textContent = @ui.getNormalItems().length
       loadingElement.className = didRefreshClassName
 
-    @ui.grammar.onDidChangeSearchTerm (source) =>
-      @searchTermElement.textContent = source
+    @ui.grammar.onDidChangeSearchTerm (regexp) =>
+      @searchTermElement.textContent = regexp?.toString() ? ''
 
     [@ignoreCaseButton, @wholeWordButton] = @container.getElementsByTagName('button')
     @ignoreCaseButton.addEventListener('click', @toggleSearchIgnoreCase)

--- a/lib/provider-information.coffee
+++ b/lib/provider-information.coffee
@@ -1,0 +1,56 @@
+toggleSelected = (element, bool) ->
+  element.classList.toggle('selected', bool)
+
+module.exports =
+class ProviderInformation
+  constructor: (@ui) ->
+    {@editor, @provider} = @ui
+
+    @container = document.createElement('div')
+    @container.className = 'narrow-provider-information'
+    # <span class='loading loading-spinner-tiny inline-block'></span>
+      # <span class='eye icon icon-eye-watch'></span>
+    @container.innerHTML = """
+    <div class='block'>
+      <span class='loading loading-spinner-tiny inline-block'></span>
+      <span class='provider-name status-added'>#{@provider.getDashName()}</span>
+      <div class='btn-group btn-group-xs'>
+        <button class='btn'>Aa</button>
+        <button class='btn'>\\b</button>
+      </div>
+      <span class='search-term'></span>
+    </div>
+    """
+
+    loadingElement = @container.getElementsByClassName('loading')[0]
+    @searchTermElement = @container.getElementsByClassName('search-term')[0]
+    willRefreshClassName = 'loading loading-spinner-tiny inline-block'
+    didRefreshClassName = 'ready icon icon-eye-watch'
+    @ui.onWillRefresh ->
+      loadingElement.className = willRefreshClassName
+    @ui.onDidRefresh =>
+      loadingElement.className = didRefreshClassName
+
+    @ui.grammar.onDidChangeSearchTerm (source) =>
+      @searchTermElement.textContent = source
+
+    [@ignoreCaseButton, @wholeWordButton] = @container.getElementsByTagName('button')
+    @ignoreCaseButton.addEventListener('click', @toggleSearchIgnoreCase)
+    @wholeWordButton.addEventListener('click', @toggleSearchWholeWord)
+
+  toggleSearchIgnoreCase: => @ui.toggleSearchIgnoreCase()
+  toggleSearchWholeWord: => @ui.toggleSearchWholeWord()
+
+  updateOptionState: ->
+    toggleSelected(@ignoreCaseButton, @provider.searchIgnoreCase)
+    toggleSelected(@wholeWordButton, @provider.searchWholeWord)
+
+  show: ->
+    @editor.decorateMarker @editor.markBufferPosition([0, 0]),
+      type: 'block'
+      item: @container
+      position: 'before'
+    @updateOptionState()
+
+  destroy: ->
+    @marker?.destroy()

--- a/lib/provider-information.coffee
+++ b/lib/provider-information.coffee
@@ -18,18 +18,23 @@ class ProviderInformation
         <button class='btn'>Aa</button>
         <button class='btn'>\\b</button>
       </div>
+      <span class='item-counter'>0</span>
       <span class='search-term'></span>
     </div>
     """
 
     loadingElement = @container.getElementsByClassName('loading')[0]
+    itemCountElement = @container.getElementsByClassName('item-counter')[0]
     @searchTermElement = @container.getElementsByClassName('search-term')[0]
     willRefreshClassName = 'loading loading-spinner-tiny inline-block'
     didRefreshClassName = 'ready icon icon-eye-watch'
     @ui.onWillRefresh ->
       loadingElement.className = willRefreshClassName
     @ui.onDidRefresh =>
+      itemCountElement.textContent = @ui.getNormalItems().length
       loadingElement.className = didRefreshClassName
+
+    # @ui.onDidStopRefreshing ->
 
     @ui.grammar.onDidChangeSearchTerm (source) =>
       @searchTermElement.textContent = source

--- a/lib/provider-information.coffee
+++ b/lib/provider-information.coffee
@@ -1,3 +1,5 @@
+{CompositeDisposable} = require 'atom'
+
 toggleSelected = (element, bool) ->
   element.classList.toggle('selected', bool)
 
@@ -5,11 +7,10 @@ module.exports =
 class ProviderInformation
   constructor: (@ui) ->
     {@editor, @provider} = @ui
+    @disposables = new CompositeDisposable
 
     @container = document.createElement('div')
     @container.className = 'narrow-provider-information'
-    # <span class='loading loading-spinner-tiny inline-block'></span>
-      # <span class='eye icon icon-eye-watch'></span>
     @container.innerHTML = """
     <div class='block'>
       <span class='loading loading-spinner-tiny inline-block'></span>
@@ -41,12 +42,9 @@ class ProviderInformation
     @ignoreCaseButton.addEventListener('click', @toggleSearchIgnoreCase)
     @wholeWordButton.addEventListener('click', @toggleSearchWholeWord)
 
-  toggleSearchIgnoreCase: => @ui.toggleSearchIgnoreCase()
-  toggleSearchWholeWord: => @ui.toggleSearchWholeWord()
-
-  updateOptionState: ->
-    toggleSelected(@ignoreCaseButton, @provider.searchIgnoreCase)
-    toggleSelected(@wholeWordButton, @provider.searchWholeWord)
+  destroy: ->
+    @disposables.destroy()
+    @marker?.destroy()
 
   show: ->
     @editor.decorateMarker @editor.markBufferPosition([0, 0]),
@@ -54,6 +52,22 @@ class ProviderInformation
       item: @container
       position: 'before'
     @updateOptionState()
+    @activateToolTips()
 
-  destroy: ->
-    @marker?.destroy()
+  updateOptionState: ->
+    toggleSelected(@ignoreCaseButton, @provider.searchIgnoreCase)
+    toggleSelected(@wholeWordButton, @provider.searchWholeWord)
+
+  toggleSearchIgnoreCase: => @ui.toggleSearchIgnoreCase()
+  toggleSearchWholeWord: => @ui.toggleSearchWholeWord()
+
+  activateToolTips: ->
+    @disposables.add atom.tooltips.add @wholeWordButton,
+      title: "wholeWord"
+      keyBindingCommand: 'narrow-ui:toggle-search-whole-word'
+      keyBindingTarget: @ui.editorElement
+
+    @disposables.add atom.tooltips.add @ignoreCaseButton,
+      title: "ignoreCase"
+      keyBindingCommand: 'narrow-ui:toggle-search-ignore-case'
+      keyBindingTarget: @ui.editorElement

--- a/lib/provider-information.coffee
+++ b/lib/provider-information.coffee
@@ -13,7 +13,7 @@ class ProviderInformation
     @container.className = 'narrow-provider-information'
     @container.innerHTML = """
     <div class='block'>
-      <span class='loading loading-spinner-tiny inline-block'></span>
+      <span class='icon icon-eye-watch'></span>
       <span class='provider-name'>#{@provider.getDashName()}</span>
       <span class='item-counter'>0</span>
       <div class='btn-group btn-group-xs'>
@@ -21,19 +21,20 @@ class ProviderInformation
         <button class='btn'>\\b</button>
       </div>
       <span class='search-term'></span>
+      <span class='loading loading-spinner-tiny inline-block'></span>
     </div>
     """
 
     loadingElement = @container.getElementsByClassName('loading')[0]
     itemCountElement = @container.getElementsByClassName('item-counter')[0]
     @searchTermElement = @container.getElementsByClassName('search-term')[0]
-    willRefreshClassName = 'search-progress loading loading-spinner-tiny inline-block'
-    didRefreshClassName = 'search-progress ready icon icon-eye-watch'
+
     @ui.onWillRefresh ->
-      loadingElement.className = willRefreshClassName
+      loadingElement.classList.remove('hide')
+
     @ui.onDidRefresh =>
       itemCountElement.textContent = @ui.getNormalItems().length
-      loadingElement.className = didRefreshClassName
+      loadingElement.classList.add('hide')
 
     @ui.grammar.onDidChangeSearchTerm (regexp) =>
       @searchTermElement.textContent = regexp?.toString() ? ''
@@ -46,11 +47,12 @@ class ProviderInformation
     @disposables.destroy()
     @marker?.destroy()
 
+  # Can be called multiple times
+  # Why? When narrow-editor's prompt row itself was removed, need to redraw to recover.
   show: ->
-    @editor.decorateMarker @editor.markBufferPosition([0, 0]),
-      type: 'block'
-      item: @container
-      position: 'before'
+    @marker?.destroy()
+    @marker = @editor.markBufferPosition([0, 0])
+    @editor.decorateMarker(@marker, type: 'block', item: @container, position: 'before')
     @updateOptionState()
     @activateToolTips()
 

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -199,15 +199,16 @@ class ProviderBase
   getFirstCharacterPointOfRow: (row) ->
     getFirstCharacterPositionForBufferRow(@editor, row)
 
-  getRegExpForSearchSource: (source) ->
+  getRegExpForSearchSource: (source, ignoreCase) ->
     if @searchWholeWord
       source = "\\b#{source}\\b"
 
-    @searchIgnoreCase ?= do =>
+    ignoreCase ?= do =>
+      # only when explict ignoreCase value are NOT provided.
+      # determine it from config and search term
       sensitivity = @getConfig('caseSensitivityForSearchTerm')
       (sensitivity is 'insensitive') or (sensitivity is 'smartcase' and not /[A-Z]/.test(source))
 
-    if @searchIgnoreCase
-      new RegExp(source, 'gi')
-    else
-      new RegExp(source, 'g')
+    flags = 'g'
+    flags += 'i' if ignoreCase
+    new RegExp(source, flags)

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -31,6 +31,7 @@ class ProviderBase
   # used by search, atom-scan, scan
   searchWholeWord: null
   searchIgnoreCase: null
+  showInformation: true
 
   getName: ->
     @constructor.name
@@ -210,15 +211,3 @@ class ProviderBase
       new RegExp(source, 'gi')
     else
       new RegExp(source, 'g')
-
-  setGrammarSearchTerm: (regexp) ->
-    source = regexp.source
-    if regexp.ignoreCase
-      searchTerm = "(?i:#{source})"
-    else
-      searchTerm = source
-    @ui.grammar.setSearchTerm(searchTerm)
-
-  clearGrammarSearchTerm: ->
-    @ui.grammar.setSearchTerm(null)
-    @ui.grammar.activate()

--- a/lib/provider/scan.coffee
+++ b/lib/provider/scan.coffee
@@ -14,6 +14,7 @@ class Scan extends ProviderBase
   updateGrammarOnQueryChange: false # for manual update
   useHighlighter: true
   showInformation: true
+  searchIgnoreCaseChangedManually: false
 
   initialize: ->
     if not @options.fromVmp and @options.uiInput? and @editor.getSelectedBufferRange().isEmpty()
@@ -32,28 +33,36 @@ class Scan extends ProviderBase
       })
     items
 
+  toggleSearchIgnoreCase: ->
+    @searchIgnoreCaseChangedManually = true
+    super
+
   getItems: ->
-    {include} = @ui.getFilterSpec()
-    if include.length
-      # 'include' hold instance of RegExp
-      regexp = @getRegExpForSearchSource(include.shift().source)
+    source = @ui.getFilterSpec().include.shift()?.source
+    if source?
+      if @searchIgnoreCaseChangedManually
+        regexp = @getRegExpForSearchSource(source, @searchIgnoreCase)
+      else
+        regexp = @getRegExpForSearchSource(source, null)
+        if regexp.ignoreCase isnt @searchIgnoreCase
+          @searchIgnoreCase = regexp.ignoreCase
+          @ui.providerInformation.updateOptionState()
+
       @ui.highlighter.setRegExp(regexp)
-      # console.log regexp
-      @ui.setGrammarSearchTerm(regexp)
+      @ui.grammar.setSearchTerm(regexp)
       @scanEditor(regexp)
     else
-      @ui.highlighter.setRegExp(null)
+      # Reset search term and grammar
       @ui.highlighter.clear()
-      @ui.clearGrammarSearchTerm()
+      @ui.highlighter.setRegExp(null)
+      @ui.grammar.setSearchTerm(null)
+      @ui.grammar.activate()
 
       @editor.buffer.getLines().map (text, row) ->
         point: new Point(row, 0)
         text: text
 
-  filterItems: (items, {include, exclude}) ->
-    if include.length is 0
-      items
-    else
-      include.shift()
-      @ui.grammar.update(include)
-      super
+  filterItems: (items, {include}) ->
+    include.shift()
+    @ui.grammar.update(include)
+    super

--- a/lib/provider/scan.coffee
+++ b/lib/provider/scan.coffee
@@ -13,6 +13,7 @@ class Scan extends ProviderBase
   ignoreSideMovementOnSyncToEditor: false
   updateGrammarOnQueryChange: false # for manual update
   useHighlighter: true
+  showInformation: true
 
   initialize: ->
     if not @options.fromVmp and @options.uiInput? and @editor.getSelectedBufferRange().isEmpty()
@@ -37,12 +38,13 @@ class Scan extends ProviderBase
       # 'include' hold instance of RegExp
       regexp = @getRegExpForSearchSource(include.shift().source)
       @ui.highlighter.setRegExp(regexp)
-      @setGrammarSearchTerm(regexp)
+      # console.log regexp
+      @ui.setGrammarSearchTerm(regexp)
       @scanEditor(regexp)
     else
       @ui.highlighter.setRegExp(null)
       @ui.highlighter.clear()
-      @clearGrammarSearchTerm()
+      @ui.clearGrammarSearchTerm()
 
       @editor.buffer.getLines().map (text, row) ->
         point: new Point(row, 0)

--- a/lib/provider/search-base.coffee
+++ b/lib/provider/search-base.coffee
@@ -42,9 +42,10 @@ class SearchBase extends ProviderBase
 
   resetRegExpForSearchTerm: ->
     source = _.escapeRegExp(@options.search)
-    @regExpForSearchTerm = @getRegExpForSearchSource(source)
+    @regExpForSearchTerm = @getRegExpForSearchSource(source, @searchIgnoreCase)
+    @searchIgnoreCase ?= @regExpForSearchTerm.ignoreCase
     @ui.highlighter.setRegExp(@regExpForSearchTerm)
-    @ui.setGrammarSearchTerm(@regExpForSearchTerm)
+    @ui.grammar.setSearchTerm(@regExpForSearchTerm)
 
   initialize: ->
     @resetRegExpForSearchTerm()

--- a/lib/provider/search-base.coffee
+++ b/lib/provider/search-base.coffee
@@ -14,6 +14,7 @@ class SearchBase extends ProviderBase
   showColumnOnLineHeader: true
   regExpForSearchTerm: null
   useHighlighter: true
+  showInformation: true
 
   checkReady: ->
     if @options.currentWord
@@ -43,7 +44,7 @@ class SearchBase extends ProviderBase
     source = _.escapeRegExp(@options.search)
     @regExpForSearchTerm = @getRegExpForSearchSource(source)
     @ui.highlighter.setRegExp(@regExpForSearchTerm)
-    @setGrammarSearchTerm(@regExpForSearchTerm)
+    @ui.setGrammarSearchTerm(@regExpForSearchTerm)
 
   initialize: ->
     @resetRegExpForSearchTerm()

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -867,13 +867,6 @@ class UI
       lineHeader = "#{lineHeader}:#{padding}#{columnText}"
     lineHeader + ": "
 
-  setGrammarSearchTerm: (regexp) ->
-    @grammar.setSearchTerm(regexp)
-
-  clearGrammarSearchTerm: ->
-    @grammar.setSearchTerm(null)
-    @grammar.activate()
-
   # vim-mode-plus integration
   # -------------------------
   vmpActivateNormalMode: ->

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -479,6 +479,7 @@ class UI
         # Need to recover query prompt
         @setPrompt()
         @moveToPrompt()
+        @providerInformation?.show() # redraw providerInformation block decoration.
       itemArea = new Range(@itemAreaStart, @editor.getEofBufferPosition())
       range = @editor.setTextInBufferRange(itemArea, texts.join("\n"), undo: 'skip')
       @editorLastRow = range.end.row

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -161,9 +161,6 @@ class UI
 
     @grammar = new Grammar(@editor, includeHeaderRules: @provider.includeHeaderGrammar)
 
-    # Depends on ui.grammar
-    @providerInformation = new ProviderInformation(this) if @provider.showInformation
-
     @itemIndicator = new ItemIndicator(this)
 
     @disposables.add @onDidMoveToItemArea =>
@@ -177,6 +174,8 @@ class UI
       @observeCursorMove()
       @observeStopChangingActivePaneItem()
     )
+    # Depends on ui.grammar and commands bound to @editorElement, so have to come last
+    @providerInformation = new ProviderInformation(this) if @provider.showInformation
 
     @constructor.register(this)
     @disposables.add new Disposable =>

--- a/styles/narrow.less
+++ b/styles/narrow.less
@@ -110,6 +110,7 @@ atom-text-editor.narrow-editor {
     color: @text-color-info;
   }
   .provider-name {
+    color: @text-color-success;
     font-size: 1.0em;
   }
   .item-counter {

--- a/styles/narrow.less
+++ b/styles/narrow.less
@@ -106,6 +106,10 @@ atom-text-editor.narrow-editor {
   padding: @component-padding/3 @component-padding;
   color: @text-color-subtle;
   font-size: 0.9em;
+  span {
+    display: inline-block;
+    text-align: center;
+  }
   .search-term {
     color: @text-color-info;
   }
@@ -114,6 +118,8 @@ atom-text-editor.narrow-editor {
     font-size: 1.0em;
   }
   .item-counter {
+    min-width: 20px;
+    text-align: right;
     color: @text-color-warning;
   }
 }

--- a/styles/narrow.less
+++ b/styles/narrow.less
@@ -110,6 +110,14 @@ atom-text-editor.narrow-editor {
     display: inline-block;
     text-align: center;
   }
+  .icon {
+    vertical-align: middle;
+  }
+  .loading {
+    .hide {
+      display: none;
+    }
+  }
   .search-term {
     color: @text-color-info;
   }

--- a/styles/narrow.less
+++ b/styles/narrow.less
@@ -99,3 +99,19 @@ atom-text-editor.narrow-editor {
     }
   }
 }
+
+// Hover Counter
+// =========================
+.narrow-provider-information {
+  padding: @component-padding/3 @component-padding;
+  font-size: 0.9em;
+  .search-term {
+    color: @text-color-info;
+  }
+  .provider-name {
+    font-size: 1.0em;
+  }
+  .ready {
+    color: @text-color-subtle;
+  }
+}

--- a/styles/narrow.less
+++ b/styles/narrow.less
@@ -104,6 +104,7 @@ atom-text-editor.narrow-editor {
 // =========================
 .narrow-provider-information {
   padding: @component-padding/3 @component-padding;
+  color: @text-color-subtle;
   font-size: 0.9em;
   .search-term {
     color: @text-color-info;
@@ -111,7 +112,7 @@ atom-text-editor.narrow-editor {
   .provider-name {
     font-size: 1.0em;
   }
-  .ready {
-    color: @text-color-subtle;
+  .item-counter {
+    color: @text-color-warning;
   }
 }


### PR DESCRIPTION
first step to fixes #115

# What's new?

- Show button to toggle `ignoreCase`, `wholeWord`, item count, loading indicator.
- Show tooltips on mouseover.
- For providers `scan`, `search`, `atom-scan`
- Achieved by block-decoration(since I want keep `narrow-editor` really normal text-editor).
  - Recover block-decoration(destroy and re-decorate) when prompt on accidental prompt row removal.
- For scan, search term can be changed multiple-time
  - Unless manually changed by button or shortcut, it respect `caseSensitivityForSearchTerm`
