### PR TITLE
auto-relax word-boundary(`\b`) in whole-word search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # 0.23.0: WIP
 - New: #121, New provider `git-diff-all`.
   - Show git diff items across projects( Existing `git-diff` shows diff for current file only )
+- New: #128 Relaxed whole-word search.
+  - What's benefit?: Now can search `@editor\b` by search `@editor` with `whole-word` enabled.
+  - In previous release, when `whole-word` was enabled, search simply `\beditor\b`( `editor` is searching word here).
+  - So when user search `@editor`, searched wth pattern `\b@editor\b`( never match ).
+  - From this release, `word-boundary`(`b`) is **automatically relaxed as long as start or end can match with boundary**
+  - Example
+    - `editor`, -> `\beditor\b` ( start and end is word-char).
+    - `@editor`, -> `@editor\b` ( relaxed start boundary ).
+    - `editor!`, -> `\beditor!` ( relaxed end boundary ).
+    - `@editor!`, -> `\b@editor!\b` ( No relax, relaxing both boundary means no-whole-word, contradict to user's intention ).
 - Fix: #123, Prevent mouse event propagation for provider-panel
   - When search-option button on provider-panel was clicked, no longer move cursor of `narrow-editor`.
   - `provider-panel` is embedded as narrow-editor's block-decoration, so need to explicitly suppress event propagation.

--- a/lib/provider/scan.coffee
+++ b/lib/provider/scan.coffee
@@ -38,12 +38,15 @@ class Scan extends ProviderBase
     super
 
   getItems: ->
-    source = @ui.getFilterSpec().include.shift()?.source
-    if source?
-      regexp = @getRegExpForSearchSource(source, {@searchIgnoreCase, @searchWholeWord})
-      if not @searchIgnoreCaseChangedManually and regexp.ignoreCase isnt @searchIgnoreCase
-        @searchIgnoreCase = regexp.ignoreCase
-        @ui.updateProviderPanel(ignoreCaseButton: @searchIgnoreCase)
+    firstQuery = @ui.getQuery().split(/\s+/)[0]
+    if firstQuery
+      if @searchIgnoreCaseChangedManually
+        regexp = @getRegExpForSearchTerm(firstQuery, {@searchWholeWord, @searchIgnoreCase})
+      else
+        regexp = @getRegExpForSearchTerm(firstQuery, {@searchWholeWord})
+        if regexp.ignoreCase isnt @searchIgnoreCase
+          @searchIgnoreCase = regexp.ignoreCase
+          @ui.updateProviderPanel(ignoreCaseButton: @searchIgnoreCase)
 
       @ui.highlighter.setRegExp(regexp)
       @ui.grammar.setSearchTerm(regexp)

--- a/lib/provider/search-base.coffee
+++ b/lib/provider/search-base.coffee
@@ -41,8 +41,7 @@ class SearchBase extends ProviderBase
     @resetRegExpForSearchTerm()
 
   resetRegExpForSearchTerm: ->
-    source = _.escapeRegExp(@options.search)
-    @searchRegExp = @getRegExpForSearchSource(source, {@searchWholeWord, @searchIgnoreCase})
+    @searchRegExp = @getRegExpForSearchTerm(@options.search, {@searchWholeWord, @searchIgnoreCase})
     @searchIgnoreCase ?= @searchRegExp.ignoreCase
     @ui.highlighter.setRegExp(@searchRegExp)
     @ui.grammar.setSearchTerm(@searchRegExp)


### PR DESCRIPTION
Fix #127

- Original idea was to improve usefulness of `narrow:scan`.
- But I found this is also benefits for `narrow:search`, `narrow:atom-scan`.
- Background is pattern `\b@word\b` is completely useless(it never match).
- In this case what user want to search is `@word\b`.
  - But atom-narrow's `\b` button is stupidly surround term with `\b` so, `@word\b` is never searchable.
  - In atom's `find-and-replace`, user can search `@word\b` by manually enter regex. but whole-word option's behavior is same as current atom-narrow(useless).
  - What I want to do here, is **relax `\b` boundary as long as start or end can match with `\b` boundary**.
- So when `whole-word`(`\b`) option  is enabled
  - `editor` => `\beditor\b` ( start and end is word-char).
  - `@editor` => `@editor\b` ( relaxed start boundary ).
  - `editor!` => `\beditor!` ( relaxed end boundary ).
  - `@editor!` => `\b@editor!\b` ( No relax, relaxing both boundary means no-whole-word, contradict to user's intention ).
