### PR TITLE
header use block-decoration, line-header use gutter

### DIFF
--- a/styles/narrow.less
+++ b/styles/narrow.less
@@ -70,22 +70,53 @@ atom-text-editor {
   }
 }
 
+div.narrow-section {
+  color: lighten(@text-color-success, 5%);
+}
+
+// atom-text-editor .gutter .line-numbers {
+//   min-width: 4em;
+// }
+
+atom-text-editor .gutter .narrow-item-line-header {
+  // display: inline-block;
+  min-width: 4em;
+  // text-align: right;
+  color: lighten(@text-color-warning, 5%);
+  position: relative;
+  white-space: nowrap;
+  opacity: 1;
+  &.cursor-line {
+    opacity: 1;
+  }
+}
+
+
 atom-text-editor.narrow-editor {
+  // .gutter {
+  // .narrow-item-line-header {
+  //   // min-width: 10px;
+  //   min-width: 4.5ch
+  //   color: red;
+  //   // width: 5em;
+  // }
+    // }
+  // }
   // Hide linumber gutter but still shows icon to fold/un-fold.
   // https://discuss.atom.io/t/use-the-gutter-without-enabling-linenumbers/2461/16
-  .gutter {
-    .line-numbers {
-      text-indent: 999em;
-      width: 23px;
-      overflow: hidden;
-      position: relative;
-      .icon-right {
-        position: absolute;
-        left: 0;
-        text-indent: 0;
-      }
-    }
-  }
+  // .gutter {
+    // .line-numbers {
+    //   text-indent: 999em;
+    //   width: 23px;
+    //   overflow: hidden;
+    //   position: relative;
+    //   .icon-right {
+    //     position: absolute;
+    //     left: 0;
+    //     text-indent: 0;
+    //   }
+    // }
+  // }
   // block-cursor on read-only mode
   &.read-only {
     &.is-focused {


### PR DESCRIPTION
This is the 3rd( or maybe 4th ) tryout to explorer HOW UI can be improved.
What I tried / evaluated in this PR is

- use **block-decoration** for header( show filePath and projectName )
- use **gutter** for line header( show line and column number )

## The result

Implementation was done without mess. but UX-wise, was NOT good, so not merge this.

## What was bad

#### line-header use gutter

- Performance impact was big, introduce extra noticeable delay especially for `narrow:search`ing `editor` in atom-core source.
- And occupying left-space in `narrow-editor` is not look good in my preference.

### header use block-decoration

- Header is not occupy big part of whole items, performance impact is NOT big.
- And header become **non-editable** by using block-decoration, which is good in some extent( in direct-edit situation ).
- But user no longer cannot copy and paste to other editor as they see in `narrow-editor`, which is counter intuitive.
- This "header as block-decoration" itself is not as bad as "line-header as gutter"
- One big benefit to use block-decoration for header is header can be more expressive by using arbitrary element for header item.
- e.g. use warn, info color for `narrow:linter` header..
- But now postpone this.


I did seem kind of UI exploration several times until now.  
But now DONE( I believe so ).  
Each time after I finish exploration / evaluation, I noticed using normal text-editor is best for intuitiveness.  
Although I have to dirty cursor movement locking / protecting header being mutated stuff.  
I'm not enough reason to maintain that dirty part.  


<img width="1407" alt="header-use-gutter-and-block-deco" src="https://cloud.githubusercontent.com/assets/155205/22857336/b3a26e4e-f0e6-11e6-9bd4-3e460341154b.png">
