### PR TITLE
flash current match / show current-marker only on preview

### DIFF
--- a/lib/highlighter.coffee
+++ b/lib/highlighter.coffee
@@ -10,16 +10,21 @@ _ = require 'underscore-plus'
 module.exports =
 class Highlighter
   regexp: null
+  lineMarker: null
 
   constructor: (@ui) ->
     @provider = @ui.provider
+    @needHighlight = @provider.supportRangeHighlight
     @markerLayerByEditor = new Map()
     @decorationByItem = new Map()
     @subscriptions = new CompositeDisposable
+
+    if @needHighlight
+      @subscriptions.add @observeUiStopRefreshing()
+
     @subscriptions.add(
-      @observeUiStopRefreshing()
-      @observeUiChangeSelectedItem()
       @observeUiPreview()
+      @observeUiConfirm()
       @observeStopChangingActivePaneItem()
     )
 
@@ -27,6 +32,7 @@ class Highlighter
 
   destroy: ->
     @clear()
+    @clearLineMarker()
     @subscriptions.dispose()
 
   # Highlight items
@@ -40,7 +46,11 @@ class Highlighter
   decorationOptions = {type: 'highlight', class: 'narrow-match'}
   highlight: (editor) ->
     return unless @regexp
+    return unless @needHighlight
+    return if isNarrowEditor(editor)
     return if @provider.boundToEditor and editor isnt @provider.editor
+    return if @markerLayerByEditor.has(editor)
+
     # Get items shown on narrow-editor and also matching editor's filePath
     if @provider.boundToEditor
       items = @ui.getNormalItems()
@@ -54,34 +64,77 @@ class Highlighter
       # FIXME: BUG decorationByItem should managed by per editor.
       @decorationByItem.set(item, editor.decorateMarker(marker, decorationOptions))
 
-  updateCurrent: ->
-    if decoration = @decorationByItem.get(@ui.getPreviouslySelectedItem())
-      updateDecoration(decoration, (cssClass) -> cssClass.replace(' current', ''))
+  # modify current item decoration
+  # -------------------------
+  resetCurrent: ->
+    return unless @needHighlight
+    @clearCurrent()
 
-    if @ui.isActive()
-      if decoration = @decorationByItem.get(@ui.getSelectedItem())
-        updateDecoration(decoration, (cssClass) -> cssClass.replace(' current', '') + ' current')
+    if decoration = @decorationByItem.get(@ui.getSelectedItem())
+      updateDecoration(decoration, (cssClass) -> cssClass + ' current')
 
+  clearCurrent: ->
+    return unless @needHighlight
+    items = [@ui.getPreviouslySelectedItem(), @ui.getSelectedItem()]
+    for item in items when item?
+      if decoration = @decorationByItem.get(item)
+        updateDecoration(decoration, (cssClass) -> cssClass.replace(' current', ''))
+
+  # lineMarker
+  # -------------------------
+  hasLineMarker: ->
+    @lineMarker?
+
+  drawLineMarker: (editor, item) ->
+    @clearLineMarker()
+    @lineMarker = editor.markBufferPosition(item.point)
+    editor.decorateMarker(@lineMarker, type: 'line', class: 'narrow-line-marker')
+
+  clearLineMarker: ->
+    @lineMarker?.destroy()
+    @lineMarker = null
+
+  # flash
+  # -------------------------
+  flashItem: (editor, item) ->
+    return unless @needHighlight
+
+    @flashMarker?.destroy()
+    clearTimeout(@clearFlashTimeout) if @clearFlashTimeout?
+
+    clearFlashMarker = =>
+      @clearFlashTimeout = null
+      @flashMarker?.destroy()
+      @flashMarker = null
+
+    @flashMarker = editor.markBufferRange(item.range)
+    editor.decorateMarker(@flashMarker, type: 'highlight', class: 'narrow-match flash')
+    @clearFlashTimeout = setTimeout(clearFlashMarker, 1000)
+
+  # Event observation
+  # -------------------------
   observeUiStopRefreshing: ->
     @ui.onDidStopRefreshing =>
       @clear()
-      for editor in getVisibleEditors() when not isNarrowEditor(editor)
-        @highlight(editor)
-      @updateCurrent()
+      @highlight(editor) for editor in getVisibleEditors()
+      @resetCurrent()
 
   observeUiPreview: ->
-    @ui.onDidPreview ({editor}) =>
-      unless @markerLayerByEditor.has(editor)
-        @highlight(editor)
-        @updateCurrent()
+    @ui.onDidPreview ({editor, item}) =>
+      @drawLineMarker(editor, item)
+      @highlight(editor)
+      @resetCurrent()
+
+  observeUiConfirm: ->
+    @ui.onDidConfirm ({editor, item}) =>
+      @clearLineMarker()
+      @clearCurrent()
 
   observeStopChangingActivePaneItem: ->
     atom.workspace.onDidStopChangingActivePaneItem (item) =>
-      if isTextEditor(item) and not isNarrowEditor(item)
-        unless @markerLayerByEditor.has(item)
-          @highlight(item)
-          @updateCurrent()
+      return unless isTextEditor(item)
+      if item isnt @ui.editor
+        @clearLineMarker()
+        @clearCurrent()
 
-  observeUiChangeSelectedItem: ->
-    @ui.onDidChangeSelectedItem =>
-      @updateCurrent()
+      @highlight(item)

--- a/lib/highlighter.coffee
+++ b/lib/highlighter.coffee
@@ -58,8 +58,9 @@ class Highlighter
     if decoration = @decorationByItem.get(@ui.getPreviouslySelectedItem())
       updateDecoration(decoration, (cssClass) -> cssClass.replace(' current', ''))
 
-    if decoration = @decorationByItem.get(@ui.getSelectedItem())
-      updateDecoration(decoration, (cssClass) -> cssClass.replace(' current', '') + ' current')
+    if @ui.isActive()
+      if decoration = @decorationByItem.get(@ui.getSelectedItem())
+        updateDecoration(decoration, (cssClass) -> cssClass.replace(' current', '') + ' current')
 
   observeUiStopRefreshing: ->
     @ui.onDidStopRefreshing =>

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -23,7 +23,7 @@ class ProviderBase
   showLineHeader: false
   showColumnOnLineHeader: false
   updateGrammarOnQueryChange: true
-  useHighlighter: false
+  supportRangeHighlight: false
 
   supportDirectEdit: false
   supportCacheItems: false

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -151,6 +151,7 @@ class ProviderBase
       point = newPoint if newPoint?
       editor.setCursorBufferPosition(point, autoscroll: false)
       editor.scrollToBufferPosition(point, center: true)
+      return editor
 
   # View
   # -------------------------

--- a/lib/provider/scan.coffee
+++ b/lib/provider/scan.coffee
@@ -12,7 +12,7 @@ class Scan extends ProviderBase
   showColumnOnLineHeader: true
   ignoreSideMovementOnSyncToEditor: false
   updateGrammarOnQueryChange: false # for manual update
-  useHighlighter: true
+  supportRangeHighlight: true
   showSearchOption: true
   searchIgnoreCaseChangedManually: false
 

--- a/lib/provider/search-base.coffee
+++ b/lib/provider/search-base.coffee
@@ -13,7 +13,7 @@ class SearchBase extends ProviderBase
   showLineHeader: true
   showColumnOnLineHeader: true
   searchRegExp: null
-  useHighlighter: true
+  supportRangeHighlight: true
   showSearchOption: true
 
   checkReady: ->

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -571,7 +571,6 @@ class UI
     @clearCurrentMarkers()
     @rowMarker = editor.markBufferRange([point, point])
     editor.decorateMarker(@rowMarker, type: 'line', class: 'narrow-result')
-    # @flashCurrentItem(editor, item)
 
   flashCurrentItem: (editor, item) ->
     @currentMatchMarker?.destroy()

--- a/styles/narrow.less
+++ b/styles/narrow.less
@@ -5,12 +5,6 @@
 // item-indicator
 // =========================
 .narrow-ui-item-indicator-base () {
-  // .octicon(arrow-right, 1em);
-  // .octicon(playback-play, 1em);
-  // .octicon(playback-fast-forward, 1em);
-  // .octicon(mirror-private);
-  // .octicon(check, 1em);
-  // .octicon(dash, 1em);
   .octicon(chevron-right, 1em);
   padding: 0 .4em;
   left: 0;
@@ -40,8 +34,23 @@ atom-text-editor {
   }
 }
 
-// row-marker
+// match highlight
 // =========================
+.flash-animation (@name, @color) {
+  @keyframes @name {
+    from { background-color: @color; }
+    to { background-color: transparent; }
+  }
+}
+.flash (@name; @duration) {
+  animation-name: @name;
+  animation-duration: @duration;
+  animation-iteration-count: 1;
+}
+
+@flash-color: fadeout(darken(@syntax-selection-flash-color, 10%), 20%);
+.flash-animation(narrow-match-flash, @flash-color);
+
 atom-text-editor {
   .narrow-match {
     .region {
@@ -56,8 +65,12 @@ atom-text-editor {
       border-color: @syntax-result-marker-color-selected;
       transition-duration: .1s;
     }
+    &.flash .region {
+      .flash(narrow-match-flash, .5s);
+    }
   }
 }
+
 
 // search min editor
 // =========================

--- a/styles/narrow.less
+++ b/styles/narrow.less
@@ -29,7 +29,7 @@ atom-text-editor .narrow-ui-item-indicator-protected {
 @row-marker-color: fadeout(lighten(@syntax-color-added, 0%), 20%);
 
 atom-text-editor {
-  .line.narrow-result {
+  .line.narrow-line-marker {
     box-shadow:0 -7px 0 -6px @row-marker-color inset;
   }
 }
@@ -66,7 +66,7 @@ atom-text-editor {
       transition-duration: .1s;
     }
     &.flash .region {
-      .flash(narrow-match-flash, .5s);
+      .flash(narrow-match-flash, 1s);
     }
   }
 }


### PR DESCRIPTION
Fixes #120


Main purpose is "**to less noisy, avoid verbosity, no disturb when editing**"".

- Avoid flash when directly confirmed ( avoid verbosity ).
- Flash when next-item / previous-item ( to let me to know where I landed )


## TODO

- [x] Move rowMarker, currentMatch flashing code to highlighter
- [ ] ~~Automatically determine flashing match strategy~~~
  - Remove `ProviderBase.prototype.useHighlighter` flag
  - if item have range field, flash else flash row for point?
- [x] Immediately clear rowMarker and current-border cssClass
  - Current `onDidStopChangingActivePaneItem` is too late when intentional confirmation.
- [x] When re-focused to narrow editor. redraw rowmarker and current-border cssClass

