### PR TITLE
double click start search / allow narrow-editor open in pending state

### DIFF
--- a/lib/highlighter.coffee
+++ b/lib/highlighter.coffee
@@ -69,6 +69,7 @@ class Highlighter
   resetCurrent: ->
     return unless @needHighlight
     @clearCurrent()
+    return unless @ui.isActive()
 
     if decoration = @decorationByItem.get(@ui.getSelectedItem())
       updateDecoration(decoration, (cssClass) -> cssClass + ' current')

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -56,6 +56,12 @@ module.exports =
       'narrow:atom-scan': => @narrow('atom-scan')
       'narrow:atom-scan-by-current-word': => @narrow('atom-scan', currentWord: true)
 
+      'narrow:toggle-search-start-by-double-click': -> settings.toggle('Search.startByDoubleClick')
+
+    @subscriptions.add atom.commands.add 'atom-text-editor', 'dblclick', =>
+      if settings.get('Search.startByDoubleClick')
+        @narrow('search', currentWord: true, activate: false, pending: true)
+
   getUi: ({skipProtected}={}) ->
     if ui = Ui.get(@lastFocusedNarrowEditor)
       if skipProtected

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -80,7 +80,8 @@ class ProviderBase
     @subscriptions = new CompositeDisposable
     @restoreEditorState = saveEditorState(editor)
     @bindEditor(editor)
-    @ui = new UI(this, query: @options.query)
+    {query, activate, pending} = @options
+    @ui = new UI(this, {query, activate, pending})
 
     @checkReady().then (ready) =>
       if ready
@@ -138,7 +139,7 @@ class ProviderBase
     # Why? if current active pane have item for that path, `workspace.open` return that item.
     # then trying to activate returned item on target-pane result in, one item activated on multiple-pane.
     # this situation cause exception.
-    pane.activate()
+    pane.activate() unless pane.isActive()
     atom.workspace.open(filePath, pending: true).then (editor) =>
       @ui.getPane().activate() unless activatePane
       editor

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -51,7 +51,7 @@ class ProviderBase
     # to override
 
   checkReady: ->
-    Promise.resolve(true)
+    Promise.resolve()
 
   bindEditor: (editor) ->
     @editorSubscriptions?.dispose()
@@ -80,13 +80,11 @@ class ProviderBase
     @subscriptions = new CompositeDisposable
     @restoreEditorState = saveEditorState(editor)
     @bindEditor(editor)
-    {query, activate, pending} = @options
-    @ui = new UI(this, {query, activate, pending})
-
-    @checkReady().then (ready) =>
-      if ready
-        @initialize()
-        @ui.start()
+    @checkReady().then =>
+      {query, activate, pending} = @options
+      @ui = new UI(this, {query, activate, pending})
+      @initialize()
+      @ui.start()
 
   subscribeEditor: (args...) ->
     @editorSubscriptions.add(args...)

--- a/lib/provider/search-base.coffee
+++ b/lib/provider/search-base.coffee
@@ -30,7 +30,6 @@ class SearchBase extends ProviderBase
     else
       @readInput().then (input) =>
         @options.search = input
-        true
 
   toggleSearchWholeWord: ->
     super

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -129,6 +129,12 @@ module.exports = new Settings 'narrow',
       default: 'smartcase'
       enum: ['smartcase', 'sensitive', 'insensitive']
     searchWholeWord: false
+    startByDoubleClick:
+      default: false
+      description: """
+      [Experimental]: start by dounble click.
+      You can toggle this value by command `narrow:toggle-search-start-by-double-click`
+      """
     agCommandArgs:
       default: "--nocolor --column --vimgrep"
       description: """

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -220,7 +220,6 @@ class UI
 
     @constructor.register(this)
     @disposables.add new Disposable =>
-      console.log "unregister"
       @constructor.unregister(this)
 
   start: ->

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -35,6 +35,14 @@ class UI
   @updateWorkspaceClassList: ->
     atom.views.getView(atom.workspace).classList.toggle('has-narrow', @uiByEditor.size)
 
+  @getNextTitleNumber: ->
+    titleNumbers = [0]
+    console.log 'size', @uiByEditor.size
+
+    @uiByEditor.forEach (ui) ->
+      titleNumbers.push(ui.titleNumber)
+    Math.max(titleNumbers...) + 1
+
   # UI.prototype
   # -------------------------
   selectedItem: null
@@ -169,6 +177,8 @@ class UI
       @vmpActivateInsertMode() if @vmpIsNormalMode()
 
   constructor: (@provider, {@query, @activate, @pending}={}) ->
+    @titleNumber = @constructor.getNextTitleNumber()
+    console.log @titleNumber
     @pending ?= false
     @activate ?= true
     @disposables = new CompositeDisposable
@@ -188,8 +198,13 @@ class UI
     @editor = atom.workspace.buildTextEditor(lineNumberGutterVisible: @provider.indentTextForLineHeader)
 
     providerDashName = @provider.getDashName()
-    title = providerDashName + '-' + @constructor.uiByEditor.size
+    title = providerDashName + '-' + @titleNumber
+    # console.log title
     @editor.getTitle = -> title
+      # @title ?= providerDashName + '-' + @constructor.uiByEditor.size
+      # console.log @title
+      # @title
+      # # @title ?= providerDashName + '-' + @constructor.uiByEditor.size
     @editor.onDidDestroy(@destroy.bind(this))
     @editorElement = @editor.element
     @editorElement.classList.add('narrow', 'narrow-editor', providerDashName)
@@ -213,6 +228,7 @@ class UI
 
     @constructor.register(this)
     @disposables.add new Disposable =>
+      console.log "unregister"
       @constructor.unregister(this)
 
   start: ->

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -36,12 +36,10 @@ class UI
     atom.views.getView(atom.workspace).classList.toggle('has-narrow', @uiByEditor.size)
 
   @getNextTitleNumber: ->
-    titleNumbers = [0]
-    console.log 'size', @uiByEditor.size
-
+    numbers = [0]
     @uiByEditor.forEach (ui) ->
-      titleNumbers.push(ui.titleNumber)
-    Math.max(titleNumbers...) + 1
+      numbers.push(ui.titleNumber)
+    Math.max(numbers...) + 1
 
   # UI.prototype
   # -------------------------
@@ -178,7 +176,6 @@ class UI
 
   constructor: (@provider, {@query, @activate, @pending}={}) ->
     @titleNumber = @constructor.getNextTitleNumber()
-    console.log @titleNumber
     @pending ?= false
     @activate ?= true
     @disposables = new CompositeDisposable
@@ -199,12 +196,7 @@ class UI
 
     providerDashName = @provider.getDashName()
     title = providerDashName + '-' + @titleNumber
-    # console.log title
     @editor.getTitle = -> title
-      # @title ?= providerDashName + '-' + @constructor.uiByEditor.size
-      # console.log @title
-      # @title
-      # # @title ?= providerDashName + '-' + @constructor.uiByEditor.size
     @editor.onDidDestroy(@destroy.bind(this))
     @editorElement = @editor.element
     @editorElement.classList.add('narrow', 'narrow-editor', providerDashName)

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -15,8 +15,8 @@ getAdjacentPaneForPane = (pane) ->
 # return pane
 getAdjacentPaneOrSplit = (basePane, {split}) ->
   pane = getAdjacentPaneForPane(atom.workspace.getActivePane()) ? switch split
-    when 'right' then currentPane.splitRight()
-    when 'down' then currentPane.splitDown()
+    when 'right' then basePane.splitRight()
+    when 'down' then basePane.splitDown()
 
   # Can not 'split' without activating new pane so rever it here
   basePane.activate() if pane.isActive()

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -13,32 +13,14 @@ getAdjacentPaneForPane = (pane) ->
 
 # Split is used when fail to find adjacent pane.
 # return pane
-activatePaneItemInAdjacentPane = (item, {split}={}) ->
-  currentPane = atom.workspace.getActivePane()
-  pane = getAdjacentPaneForPane(currentPane)
-
-  if pane?
-    pane.activate()
-    pane.activateItem(item)
-    return pane
-  else
-    return switch split
-      when 'right'
-        currentPane.splitRight(items: [item])
-      when 'down'
-        currentPane.splitDown(items: [item])
-
 getAdjacentPaneOrSplit = (basePane, {split}) ->
-  pane = getAdjacentPaneForPane(basePane)
-  if pane?
-    pane
-  else
-    pane = switch split
-      when 'right' then basePane.splitRight()
-      when 'down' then basePane.splitDown()
-    # Can not 'split' without activating new pane so rever it here
-    basePane.activate()
-    pane
+  pane = getAdjacentPaneForPane(atom.workspace.getActivePane()) ? switch split
+    when 'right' then currentPane.splitRight()
+    when 'down' then currentPane.splitDown()
+
+  # Can not 'split' without activating new pane so rever it here
+  basePane.activate() if pane.isActive()
+  pane
 
 smartScrollToBufferPosition = (editor, point) ->
   editorElement = editor.element
@@ -153,7 +135,6 @@ itemForGitDiff = (diff, {editor, filePath}) ->
 
 module.exports = {
   getAdjacentPaneForPane
-  activatePaneItemInAdjacentPane
   getAdjacentPaneOrSplit
   smartScrollToBufferPosition
   registerElement


### PR DESCRIPTION
#135 

- Allow `narrow-editor` open in **pending** state
- activate providerPane after open if `activate` was set to `alse` on UI constructor ( default = true )

- mouse double click start `narrow:scan-by-current-word` if configured.
