### PR TITLE
Support text.md grammar scope for special indentation handling of symbols provider

### DIFF
--- a/lib/provider/symbols.coffee
+++ b/lib/provider/symbols.coffee
@@ -28,7 +28,7 @@ class Symbols extends ProviderBase
 
   getLevelForRow: (row) ->
     # For gfm source, determine level by counting leading '#' chars( use header level ).
-    if @editor.getGrammar().scopeName is 'source.gfm'
+    if @editor.getGrammar().scopeName in ['source.gfm', 'text.md']
       lineText = @editor.lineTextForBufferRow(row)
       (lineText.match(/#+/)?[0]?.length - 1) ? 0
     else


### PR DESCRIPTION
The `language-markdown` package, which is a drop-in replacement for `language-gfm`, uses the grammar scope `text.md` instead of `source.gfm`.

This pull request adds `text.md` to the grammar scopes that get special indentation handling for markdown headers in the symbols provider.