### PR TITLE
per file refresh support for search and atom-scan

### DIFF
--- a/lib/provider/atom-scan.coffee
+++ b/lib/provider/atom-scan.coffee
@@ -39,8 +39,11 @@ class AtomScan extends SearchBase
 
   getItems: (filePath) ->
     if filePath?
-      itemsPromise = @scanFilePath(@searchRegExp, filePath).then (newItems) =>
-        @replaceOrAppendItemsForFilePath(@items, filePath, newItems)
+      if atom.project.contains(filePath) # ignore non-project file for consistency
+        itemsPromise = @scanFilePath(@searchRegExp, filePath).then (newItems) =>
+          @replaceOrAppendItemsForFilePath(@items, filePath, newItems)
+      else
+        itemsPromise = Promise.resolve(@items)
     else
       itemsPromise = @scanWorkspace(@searchRegExp)
 

--- a/lib/provider/bookmarks.coffee
+++ b/lib/provider/bookmarks.coffee
@@ -32,7 +32,4 @@ class Bookmarks extends ProviderBase
     items = []
     for {editor, markerLayer} in getBookmarks() when markerLayer.getMarkerCount() > 0
       items.push(@getItemsForEditor(editor, markerLayer)...)
-    @getItemsWithHeaders(items)
-
-  filterItems: (items, filterSpec) ->
-    @getItemsWithoutUnusedHeader(super)
+    items

--- a/lib/provider/git-diff-all.coffee
+++ b/lib/provider/git-diff-all.coffee
@@ -28,9 +28,5 @@ class GitDiffAll extends ProviderBase
     eachModifiedFilePaths (repo, filePath) ->
       promises.push(getItemsForFilePath(repo, filePath))
 
-    Promise.all(promises).then (items) =>
-      items = _.compact(_.flatten(items))
-      @getItemsWithHeaders(items)
-
-  filterItems: (items, filterSpec) ->
-    @getItemsWithoutUnusedHeader(super)
+    Promise.all(promises).then (items) ->
+      _.compact(_.flatten(items))

--- a/lib/provider/project-symbols.coffee
+++ b/lib/provider/project-symbols.coffee
@@ -97,24 +97,17 @@ class ProjectSymbols extends ProviderBase
     # Refresh watching target tagFile on each execution to catch-up change in outer-world.
     watchTagsFiles()
 
-    if cache = getCachedItems()
-      itemsPromise = Promise.resolve(cache)
-    else
-      itemsPromise = @readTags().then (tags) ->
-        # Better interests suggestion? I want this less noisy.
-        kindOfInterests = 'cfm'
+    return cache if cache = getCachedItems()
 
-        items = tags
-          .filter (tag) -> tag.kind in kindOfInterests
-          .map(itemForTag)
-          .filter (item) -> item.point?
-          .sort(compareByPoint)
-        items = _.uniq items, (item) -> item.filePath + item.text
-        setCachedItems(items)
-        items
+    @readTags().then (tags) ->
+      # Better interests suggestion? I want this less noisy.
+      kindOfInterests = 'cfm'
 
-    itemsPromise.then (items) =>
-      @getItemsWithHeaders(items)
-
-  filterItems: (items, filterSpec) ->
-    @getItemsWithoutUnusedHeader(super)
+      items = tags
+        .filter (tag) -> tag.kind in kindOfInterests
+        .map(itemForTag)
+        .filter (item) -> item.point?
+        .sort(compareByPoint)
+      items = _.uniq items, (item) -> item.filePath + item.text
+      setCachedItems(items)
+      items

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -1,4 +1,3 @@
-path = require 'path'
 _ = require 'underscore-plus'
 {Point, CompositeDisposable} = require 'atom'
 {
@@ -254,34 +253,3 @@ class ProviderBase
     flags = 'g'
     flags += 'i' if searchIgnoreCase
     new RegExp(source, flags)
-
-  getItemsWithoutUnusedHeader: (items) ->
-    normalItems = items.filter(isNormalItem)
-    filePaths = _.uniq(_.pluck(normalItems, "filePath"))
-    projectNames = _.uniq(_.pluck(normalItems, "projectName"))
-
-    items.filter (item) ->
-      if item.header?
-        if item.projectHeader?
-          item.projectName in projectNames
-        else
-          item.filePath in filePaths
-      else
-        true
-
-  getItemsWithHeaders: (_items) ->
-    items = []
-
-    # Inject projectName from filePath
-    for item in _items
-      item.projectName = path.basename(atom.project.relativizePath(item.filePath)[0])
-
-    for projectName, itemsInProject of _.groupBy(_items, (item) -> item.projectName)
-      header = "# #{projectName}"
-      items.push({header, projectName, projectHeader: true, skip: true})
-
-      for filePath, itemsInFile of _.groupBy(itemsInProject, (item) -> item.filePath)
-        header = "## " + atom.project.relativize(filePath)
-        items.push({header, projectName, filePath, skip: true})
-        items.push(itemsInFile...)
-    items

--- a/lib/provider/search-base.coffee
+++ b/lib/provider/search-base.coffee
@@ -47,9 +47,6 @@ class SearchBase extends ProviderBase
   initialize: ->
     @resetRegExpForSearchTerm()
 
-  filterItems: (items, filterSpec) ->
-    @getItemsWithoutUnusedHeader(super)
-
   # If passed items have filePath's item, replace old items with new items.
   # If passed items have no filePath's item, append to end.
   replaceOrAppendItemsForFilePath: (items, filePath, newItems) ->

--- a/lib/provider/search-base.coffee
+++ b/lib/provider/search-base.coffee
@@ -2,7 +2,7 @@ _ = require 'underscore-plus'
 
 ProviderBase = require './provider-base'
 {Disposable} = require 'atom'
-{getCurrentWord} = require '../utils'
+{getCurrentWord, findFirstAndLastIndexBy} = require '../utils'
 
 module.exports =
 class SearchBase extends ProviderBase
@@ -49,3 +49,17 @@ class SearchBase extends ProviderBase
 
   filterItems: (items, filterSpec) ->
     @getItemsWithoutUnusedHeader(super)
+
+  # If passed items have filePath's item, replace old items with new items.
+  # If passed items have no filePath's item, append to end.
+  replaceOrAppendItemsForFilePath: (items, filePath, newItems) ->
+    amountOfRemove = 0
+    indexToInsert = items.length - 1
+
+    [firstIndex, lastIndex] = findFirstAndLastIndexBy(items, (item) -> item.filePath is filePath)
+    if firstIndex? and lastIndex?
+      indexToInsert = firstIndex
+      amountOfRemove = lastIndex - firstIndex + 1
+
+    items.splice(indexToInsert, amountOfRemove, newItems...)
+    items

--- a/lib/provider/search.coffee
+++ b/lib/provider/search.coffee
@@ -54,10 +54,10 @@ class Search extends SearchBase
 
     super
 
-  getItems: ->
+  getItems: (filePath) ->
     searchPromises = []
     for project in @options.projects ? atom.project.getPaths()
-      searchPromises.push(@search(@searchRegExp, {project}))
+      searchPromises.push(@search(@searchRegExp, {project, filePath}))
 
     searchTermLength = @searchTerm.length
     Promise.all(searchPromises).then (values) =>

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -396,17 +396,18 @@ class Ui
     @emitWillRefreshManually()
     @refresh(options)
 
-  refresh: ({force, selectFirstItem}={}) ->
+  refresh: ({force, selectFirstItem, filePath}={}) ->
     @emitWillRefresh()
 
-    if @cachedItems? and not force
-      promiseForItems = Promise.resolve(@cachedItems)
-    else
-      promiseForItems = Promise.resolve(@provider.getItems()).then (items) =>
-        if @provider.showLineHeader
-          injectLineHeader(items, showColumn: @provider.showColumnOnLineHeader)
-        @cachedItems = items if @provider.supportCacheItems
-        items
+    getItems = =>
+      if @cachedItems? and not force
+        Promise.resolve(@cachedItems)
+      else
+        Promise.resolve(@provider.getItems(filePath)).then (items) =>
+          if @provider.showLineHeader
+            injectLineHeader(items, showColumn: @provider.showColumnOnLineHeader)
+          @cachedItems = items if @provider.supportCacheItems
+          items
 
     @lastQuery = @getQuery()
     sensitivity = @provider.getConfig('caseSensitivityForNarrowQuery')
@@ -414,7 +415,7 @@ class Ui
     if @provider.updateGrammarOnQueryChange
       @grammar.update(filterSpec.include) # No need to highlight excluded items
 
-    promiseForItems.then (items) =>
+    getItems().then (items) =>
       if @excludedFiles.length
         items = items.filter (item) => item.filePath not in @excludedFiles
       items = @provider.filterItems(items, filterSpec)
@@ -654,15 +655,16 @@ class Ui
 
     # Suppress refresh while ui is active.
     # Important to update-real-file don't cause auto-refresh.
-    refresh = => @refresh(force: true) unless @isActive()
 
     if @provider.boundToSingleFile
       # Refresh only when newFilePath is undefined or different from oldFilePath
       unless isDefinedAndEqual(oldFilePath, newFilePath)
         @refresh(force: true)
-      @syncSubcriptions.add editor.onDidStopChanging(refresh)
+      @syncSubcriptions.add editor.onDidStopChanging =>
+        @refresh(force: true) unless @isActive()
     else
-      @syncSubcriptions.add editor.onDidSave(refresh)
+      @syncSubcriptions.add editor.onDidSave (event) =>
+        @refresh(force: true, filePath: event.path) unless @isActive()
 
   # vim-mode-plus integration
   # -------------------------

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -14,6 +14,8 @@ _ = require 'underscore-plus'
   ensureNoModifiedFileForChanges
   ensureNoConflictForChanges
   isNormalItem
+  getItemsWithHeaders
+  getItemsWithoutUnusedHeader
 } = require './utils'
 settings = require './settings'
 Grammar = require './grammar'
@@ -406,6 +408,7 @@ class Ui
         Promise.resolve(@provider.getItems(filePath)).then (items) =>
           if @provider.showLineHeader
             injectLineHeader(items, showColumn: @provider.showColumnOnLineHeader)
+          items = getItemsWithHeaders(items) unless @provider.boundToSingleFile
           @cachedItems = items if @provider.supportCacheItems
           items
 
@@ -419,6 +422,7 @@ class Ui
       if @excludedFiles.length
         items = items.filter (item) => item.filePath not in @excludedFiles
       items = @provider.filterItems(items, filterSpec)
+      items = getItemsWithoutUnusedHeader(items) unless @provider.boundToSingleFile
 
       if (not selectFirstItem) and @items.hasSelectedItem()
         oldSelectedItem = @items.getSelectedItem()

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -228,6 +228,18 @@ isNormalItem = (item) ->
 compareByPoint = (a, b) ->
   a.point.compare(b.point)
 
+# Since underscore-plus not support _.findIndex
+findIndexBy = (items, fn) ->
+  for item, i in items when fn(item)
+    return i
+
+findLastIndexBy = (items, fn) ->
+  for item, i in items by -1 when fn(item)
+    return i
+
+findFirstAndLastIndexBy = (items, fn) ->
+  [findIndexBy(items, fn), findLastIndexBy(items, fn)]
+
 module.exports = {
   getNextAdjacentPaneForPane
   getPreviousAdjacentPaneForPane
@@ -254,4 +266,5 @@ module.exports = {
   ensureNoModifiedFileForChanges
   isNormalItem
   compareByPoint
+  findFirstAndLastIndexBy
 }

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,3 +1,4 @@
+path = require 'path'
 {Point} = require 'atom'
 _ = require 'underscore-plus'
 
@@ -240,6 +241,39 @@ findLastIndexBy = (items, fn) ->
 findFirstAndLastIndexBy = (items, fn) ->
   [findIndexBy(items, fn), findLastIndexBy(items, fn)]
 
+getItemsWithoutUnusedHeader = (items) ->
+  normalItems = items.filter(isNormalItem)
+  filePaths = _.uniq(_.pluck(normalItems, "filePath"))
+  projectNames = _.uniq(_.pluck(normalItems, "projectName"))
+
+  items.filter (item) ->
+    if item.header?
+      if item.projectHeader?
+        item.projectName in projectNames
+      else if item.filePath?
+        item.filePath in filePaths
+      else
+        true
+    else
+      true
+
+getItemsWithHeaders = (_items) ->
+  items = []
+
+  # Inject projectName from filePath
+  for item in _items
+    item.projectName = path.basename(atom.project.relativizePath(item.filePath)[0])
+
+  for projectName, itemsInProject of _.groupBy(_items, (item) -> item.projectName)
+    header = "# #{projectName}"
+    items.push({header, projectName, projectHeader: true, skip: true})
+
+    for filePath, itemsInFile of _.groupBy(itemsInProject, (item) -> item.filePath)
+      header = "## " + atom.project.relativize(filePath)
+      items.push({header, projectName, filePath, skip: true})
+      items.push(itemsInFile...)
+  items
+
 module.exports = {
   getNextAdjacentPaneForPane
   getPreviousAdjacentPaneForPane
@@ -267,4 +301,6 @@ module.exports = {
   isNormalItem
   compareByPoint
   findFirstAndLastIndexBy
+  getItemsWithHeaders
+  getItemsWithoutUnusedHeader
 }


### PR DESCRIPTION
Fixes #105


- Now `atom-scan` and `search` can re-scan per filePath.
- projectName and filePath header injection is done by Ui on every refresh() for simplicity.
- Even in per filePath refresh, ui, re-render whole items area for simplicity.
- I won't partial render for items area until I find it really necessary.

### One minor UX diff.

* Completely new file is always added to end of items.

1. when `filePath-A` contains `abc`, and `scan`.
items for `filePath-A` rendered on `narrow-editor`

2. Delete all `abc` from `filePath-A` then save.
items for `filePath-A` removed from `narrow-editor`

3. Add `abc` to `filePath-A` then save.
items for `filePath-A` appended to existing items and rendered at bottom of `narrow-editor`.

- Even if items for `filePath-A` appeared at **top of** `narrow-editor` at **1**.
- Items are rendered at **bottom of** `narrow-editor` at **3**.
- So the result just after `search`( or `atom-scan` ) and the result after "remove-then-add" can be different.
