### PR TITLE
config to preserve query-for-select-files across provider/same-provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # 0.33.0: WIP
-- Improve: Restore following ui properties on `narrow:reopen`.
-  - `excludeFiles`: State of excluded files
-  - `queryForSelectFiles` : Query for `select-files`
+- New `select-files` provider specific `rememberQuery` config.
+  - Default `false`.
+  - When set to `true`, remember query **per provider basis** and apply it at startup.
+  - When `narrow:reopen` initial `select-files` query applying is skipped to respect restored `excludedFiles`.
+- Improve: folder-icon on `control-bar` is green highlighted to indicate some files are excluded.
+  - This is indicating files are **actually** excluded( filtered ).
+  - **Not** indicating remembered `select-files` query is applied.
+    - e.g. Applying remembered `.md!` query to non-markdown-file-items have no effect, no highlight.
+- Improve: `narrow:reopen` restored excluded-files state and query used for `select-files`.
+
 # 0.32.1:
 - Fix: wildcard was not expanded correctly when query words include single char query.
 - Doc: Add link to wiki on README.md.

--- a/README.md
+++ b/README.md
@@ -240,7 +240,6 @@ Frequently using keymap with my keymap.
   'cmd-f': 'narrow:focus' # focus to narrow-editor
   'cmd-i': 'narrow:focus-prompt' # focus to prompt of narrow-editor
   'ctrl-cmd-l': 'narrow:refresh' # manually refresh items
-  'backspace': 'narrow:close'
 
 # narrow-editor regardless of mode of vim
 'atom-text-editor.narrow.narrow-editor[data-grammar="source narrow"]':

--- a/lib/control-bar.coffee
+++ b/lib/control-bar.coffee
@@ -104,6 +104,9 @@ class ControlBar
       autoPreview: @ui.autoPreview
       protected: @ui.protected
 
+    if @stateElements.selectFiles?
+      states.selectFiles = @ui.excludedFiles.length
+
     if @showSearchOption
       states.ignoreCaseButton = @provider.searchIgnoreCase
       states.wholeWordButton = @provider.searchWholeWord

--- a/lib/control-bar.coffee
+++ b/lib/control-bar.coffee
@@ -104,9 +104,6 @@ class ControlBar
       autoPreview: @ui.autoPreview
       protected: @ui.protected
 
-    if @stateElements.selectFiles?
-      states.selectFiles = @ui.excludedFiles.length
-
     if @showSearchOption
       states.ignoreCaseButton = @provider.searchIgnoreCase
       states.wholeWordButton = @provider.searchWholeWord

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -118,6 +118,7 @@ class ProviderBase
       uiProperties: {
         excludedFiles: @ui.excludedFiles
         queryForSelectFiles: @ui.queryForSelectFiles
+        needRebuildExcludedFiles: @ui.needRebuildExcludedFiles
       }
     }
 

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -117,7 +117,7 @@ class ProviderBase
       properties: properties
       uiProperties: {
         excludedFiles: @ui.excludedFiles
-        queryForSelectedFiles: @ui.queryForSelectedFiles
+        queryForSelectFiles: @ui.queryForSelectFiles
       }
     }
 

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -108,7 +108,7 @@ class ProviderBase
       @searchIgnoreCaseChangedManually
       @searchTerm
     }
-    for property in  @propertiesToRestoreOnReopen ? []
+    for property in @propertiesToRestoreOnReopen ? []
       properties[property] = this[property]
 
     {

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -192,7 +192,7 @@ module.exports = new Settings 'narrow',
     autoPreviewOnQueryChange: false
     negateNarrowQueryByEndingExclamation: true
     persistQuery:
-      default: 'same-provider'
+      default: 'never'
       enum: ['never', 'same-provider', 'across-providers']
     closeOnConfirm: true
     revealOnStartCondition:

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -191,6 +191,9 @@ module.exports = new Settings 'narrow',
     autoPreview: false
     autoPreviewOnQueryChange: false
     negateNarrowQueryByEndingExclamation: true
+    preserveQueryScope:
+      default: 'same-provider'
+      enum: ['never', 'same-provider', 'all-providers']
     closeOnConfirm: true
     revealOnStartCondition:
       default: 'never'

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -196,5 +196,5 @@ module.exports = new Settings 'narrow',
       default: 'never'
     rememberQuery:
       default: false
-      description: "Remember query per provider basis and apply at startup"
+      description: "Remember query per provider basis and apply it at startup"
   )

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -191,9 +191,9 @@ module.exports = new Settings 'narrow',
     autoPreview: false
     autoPreviewOnQueryChange: false
     negateNarrowQueryByEndingExclamation: true
-    preserveQueryScope:
+    persistQuery:
       default: 'same-provider'
-      enum: ['never', 'same-provider', 'all-providers']
+      enum: ['never', 'same-provider', 'across-providers']
     closeOnConfirm: true
     revealOnStartCondition:
       default: 'never'

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -191,10 +191,10 @@ module.exports = new Settings 'narrow',
     autoPreview: false
     autoPreviewOnQueryChange: false
     negateNarrowQueryByEndingExclamation: true
-    persistQuery:
-      default: 'never'
-      enum: ['never', 'same-provider', 'across-providers']
     closeOnConfirm: true
     revealOnStartCondition:
       default: 'never'
+    rememberQuery:
+      default: false
+      description: "Remember query per provider basis and apply at startup"
   )

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -68,7 +68,7 @@ class Ui
   modifiedState: null
   readOnly: false
   protected: false
-  excludedFiles: []
+  excludedFiles: null
   queryForSelectedFiles: null
 
   onDidMoveToPrompt: (fn) -> @emitter.on('did-move-to-prompt', fn)
@@ -181,6 +181,7 @@ class Ui
 
   constructor: (@provider, {@query}={}, properties) ->
     _.extend(this, properties) if properties?
+    @excludedFiles ?= []
     @query ?= ''
     @disposables = new CompositeDisposable
     @emitter = new Emitter
@@ -387,6 +388,7 @@ class Ui
     filePath = @items.getSelectedItem()?.filePath
     if filePath? and (filePath not in @excludedFiles)
       @excludedFiles.push(filePath)
+      @updateControlBarExcludedFilesState()
       @moveToDifferentFileItem('next')
       @refresh()
 
@@ -400,7 +402,11 @@ class Ui
 
   setQueryForSelectFiles: (@queryForSelectedFiles) ->
 
+  updateControlBarExcludedFilesState: ->
+    @controlBar.updateStateElements(selectFiles: @excludedFiles.length)
+
   setExcludedFiles: (@excludedFiles) ->
+    @updateControlBarExcludedFilesState()
     @refresh()
 
   clearExcludedFiles: ->

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -69,7 +69,7 @@ class Ui
   readOnly: false
   protected: false
   excludedFiles: null
-  queryForSelectedFiles: null
+  queryForSelectFiles: null
 
   onDidMoveToPrompt: (fn) -> @emitter.on('did-move-to-prompt', fn)
   emitDidMoveToPrompt: -> @emitter.emit('did-move-to-prompt')
@@ -396,11 +396,11 @@ class Ui
     return if @provider.boundToSingleFile
     SelectFiles ?= require("./provider/select-files")
     options =
-      query: @queryForSelectedFiles
+      query: @queryForSelectFiles
       clientUi: this
     new SelectFiles(@editor, options).start()
 
-  setQueryForSelectFiles: (@queryForSelectedFiles) ->
+  setQueryForSelectFiles: (@queryForSelectFiles) ->
 
   updateControlBarExcludedFilesState: ->
     @controlBar.updateStateElements(selectFiles: @excludedFiles.length)

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -395,8 +395,11 @@ class Ui
   selectFiles: ->
     return if @provider.boundToSingleFile
     SelectFiles ?= require("./provider/select-files")
+    # NOTE: `queryForSelectFiles` is used when narrow:reopen
+    # This is for restoring last state of closed provider.
+    # So prioritized over more general persist-query by `SelectFiles.getLastQuery`.
     options =
-      query: @queryForSelectFiles
+      query: @queryForSelectFiles ? SelectFiles.getLastQuery(@provider.name)
       clientUi: this
     new SelectFiles(@editor, options).start()
 


### PR DESCRIPTION
Fix #162

`select-files` provider is available for not `boundToSingleFile` provider.

Which is available for `o` marked providers.

- o `atom-scan`
- o `bookmarks`
- o `git-diff-all`
- o `linter`
- o `project-symbols`
- o `search`

# Summary of changes

- New `rememberQuery` config for `select-files` provider
  - When set to `true`, remember query **per provider basis** and apply it at startup.
  - When `narrow:reopen` initial `select-files` query applying is skipped to respect restored `excludedFiles`.
- Improve: folder-icon on `control-bar` highlighted when some files are excluded.
  - This is indicating files are **actually** excluded( filtered ).
  - If remembered `select-files` was applied but no file exclusion happens, then no-highlight.
    - e.g. Applying remembered `.md!` query to non-markdown-file-items have no effect, no highlight.
