### PR TITLE
add query expression for word-boundary and use it in symbols and project-symbols

### DIFF
--- a/lib/get-filter-spec-for-query.coffee
+++ b/lib/get-filter-spec-for-query.coffee
@@ -20,6 +20,17 @@ getRegExpForWord = (word, {wildcard, sensitivity}={}) ->
   else
     pattern = _.escapeRegExp(word)
 
+  # Translate
+  # - ">word<" to "\bword\b"
+  # - ">word" to "\bword"
+  # - "word<" to "word\b"
+  if /^>./.test(pattern)
+    pattern = pattern[1...]
+    pattern = "\\b" + pattern if /^\w/.test(pattern)
+  if /.<$/.test(pattern)
+    pattern = pattern[...-1]
+    pattern = pattern + "\\b" if /\w$/.test(pattern)
+
   if (sensitivity is 'sensitive') or (sensitivity is 'smartcase' and /[A-Z]/.test(word))
     new RegExp(pattern)
   else

--- a/lib/provider/project-symbols.coffee
+++ b/lib/provider/project-symbols.coffee
@@ -67,6 +67,7 @@ itemForTag = (tag) ->
 module.exports =
 class ProjectSymbols extends ProviderBase
   showLineHeader: false
+  queryWordBoundaryOnByCurrentWordInvocation: true
 
   onBindEditor: ({newEditor}) ->
     # Refresh item.point in cachedItems for saved filePath.

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -56,6 +56,7 @@ class ProviderBase
   searchIgnoreCaseChangedManually: false
   showSearchOption: false
   querySelectedText: true
+  queryWordBoundaryOnByCurrentWordInvocation: false
 
   getConfig: (name) ->
     value = settings.get("#{@name}.#{name}")
@@ -161,8 +162,14 @@ class ProviderBase
 
   getInitialQuery: (editor) ->
     query = @options.query
-    query or= editor.getSelectedText() if @querySelectedText
-    query or= getCurrentWord(editor) if @options.queryCurrentWord
+
+    if not query and @querySelectedText
+      query = editor.getSelectedText()
+
+    if not query and @options.queryCurrentWord
+      query = getCurrentWord(editor)
+      if @queryWordBoundaryOnByCurrentWordInvocation
+        query = ">" + query + "<"
     query
 
   subscribeEditor: (args...) ->

--- a/lib/provider/symbols.coffee
+++ b/lib/provider/symbols.coffee
@@ -13,7 +13,7 @@ module.exports =
 class Symbols extends ProviderBase
   boundToSingleFile: true
   showLineHeader: false
-
+  queryWordBoundaryOnByCurrentWordInvocation: true
   items: null
 
   onBindEditor: ({newEditor}) ->


### PR DESCRIPTION
Fix #169
Related #50

# What will change

Add query expression which specify word-boundary(`\b`) search.

Here is how query translated
```
  # Translate
  # - ">word<" to "\bword\b"
  # - ">word" to "\bword"
  # - "word<" to "word\b"
  if /^>./.test(pattern)
```

If `\b` is meaningless(e.g. `>=`), it don't add `\b`, but remove `>` or `<` for consistency.

NOTE: I also evaluated not-trim starting `>` so that user don't need to search by `>>=` for search `>=` literal.  
But it was not obvious when `>` is removed or not removed, which make user learning difficult, so avoided this approach.


# Auto enable word boundary query when symbols and project-symbols invoked by by-current-word command

Purpose: To make quick previewing by `symbols-by-current-word` or `project-symbols-by-current-word` further useful.

# Before: Problematic situation

1. Place cursor on `@refresh` function and invoke
2. `narrow:symbols-by-current-word`: Previewing unwanted function(multiple symbols which contains `refresh`)
3. `narrow:project-symbols-by-current-word`: Previewing unwanted function(multiple symbols which contains `refresh`)


![atom-narrow-symbols-boundary-query-before](https://cloud.githubusercontent.com/assets/155205/23740094/570efbee-04e5-11e7-93dd-92f103dd5f6b.gif)

# After: Find target thanks to `>refresh<` query.

1. Place cursor on `@refresh` function and invoke
2. `narrow:symbols-by-current-word`: Previewing single `preview` function.
3. `narrow:project-symbols-by-current-word`:  Previewing single `preview` function.


![atom-narrow-symbols-boundary-query-after](https://cloud.githubusercontent.com/assets/155205/23740098/5bf38314-04e5-11e7-8765-d245be73c82d.gif)
