### PR TITLE
[experiment] activateOnStart config param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.39.0: WIP
+- Improve: `search` and `atom-scan` provider config no longer show `on-input` choice for `revealOnStartCondition`.
+  - Since it's have no effect( `search` and `atom-scan` have always no-input, never met condition of `on-input` )
+- New, Experimental: #177 New config param `focusOnStartCondition` to control whether initially focus to `narrow-editor` or not.
+  - Possible values are
+    - `always`( default ): always focus to `narrow-editor` on start.
+    - `never`: never focus to `narrow-editor` on start.
+    - `no-input`: focus when initial query was empty( this choice is not available for `search`, `atom-scan` )
+
 # 0.38.2:
 - Fix: `narrow:search` with searcher `rg`, `smartcase` didn't work correctly.
   - Because of ignorance of default behavior diff between `ag` and `rg`.

--- a/lib/provider/provider-base.coffee
+++ b/lib/provider/provider-base.coffee
@@ -65,14 +65,18 @@ class ProviderBase
     else
       value
 
-  needAutoReveal: ->
-    switch @getConfig('revealOnStartCondition')
-      when 'never'
-        false
-      when 'always'
-        true
-      when 'on-input'
-        @query?.length
+  getOnStartConditionValueFor: (name) ->
+    switch @getConfig(name)
+      when 'never' then false
+      when 'always' then true
+      when 'on-input' then @query?.length
+      when 'no-input' then not @query?.length
+
+  needRevealOnStart: ->
+    @getOnStartConditionValueFor('revealOnStartCondition')
+
+  needActivateOnStart: ->
+    @getOnStartConditionValueFor('focusOnStartCondition')
 
   initialize: ->
     # to override

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -12,11 +12,12 @@ complimentField = (config, injectTitle=false) ->
   # skip if value which aleady have `type` field.
   # Also translate bare `boolean` value to {default: `boolean`} object
   for key in Object.keys(config)
-    if typeof(config[key]) is 'boolean'
+    if inferedType = inferType(config[key])
       config[key] = {default: config[key]}
+      config[key].type = inferedType
 
     value = config[key]
-    value.type = inferType(value.default) unless value.type?
+    value.type ?= inferType(value.default)
     value.title ?= _.uncamelcase(key) if injectTitle
 
   # Inject order props to display orderd in setting-view
@@ -72,45 +73,10 @@ class Settings
       content.push "- `#{param}`"
     atom.notifications.addWarning content.join("\n"), dismissable: true
 
-newProviderConfig = (otherProperties) ->
-  properties =
-    directionToOpen:
-      default: 'inherit'
-      enum: [
-        'inherit'
-        'right'
-        'right:never-use-previous-adjacent-pane'
-        'right:always-new-pane'
-        'down'
-        'down:never-use-previous-adjacent-pane'
-        'down:always-new-pane'
-      ]
-    caseSensitivityForNarrowQuery:
-      default: 'inherit'
-      enum: ['inherit', 'smartcase', 'sensitive', 'insensitive']
-    activateOnStart:
-      default: 'always'
-      enum: ['inherit', 'never', 'always', 'on-input']
-    negateNarrowQueryByEndingExclamation: false
-    autoPreview: true
-    autoPreviewOnQueryChange: true
-    closeOnConfirm: true
-    revealOnStartCondition:
-      default: 'always'
-      enum: ['inherit', 'never', 'always', 'on-input']
-
-  _.deepExtend(properties, otherProperties) if otherProperties?
-
-  return {
-    type: 'object'
-    properties: complimentField(properties, true)
-  }
-
-module.exports = new Settings 'narrow',
+globalSettings =
   autoShiftReadOnlyOnMoveToItemArea:
     default: true
     description: "When cursor moved to item area automatically change to read-only mode"
-
   directionToOpen:
     default: 'right'
     enum: [
@@ -122,50 +88,54 @@ module.exports = new Settings 'narrow',
       'down:always-new-pane'
     ]
     description: "Where to open narrow-editor when open by split pane."
-
   caseSensitivityForNarrowQuery:
     default: 'smartcase'
     enum: ['smartcase', 'sensitive', 'insensitive']
     description: "Case sensitivity of your query in narrow-editor"
-
   activateOnStart:
     default: 'always'
     enum: ['never', 'always', 'on-input']
-
   confirmOnUpdateRealFile: true
 
-  # Per providers settings
-  # -------------------------
-  GitDiffAll: newProviderConfig()
-  Fold: newProviderConfig(
+inheritGlobalEnum = (name) ->
+  default: 'inherit'
+  enum: ['inherit', globalSettings[name].enum...]
+
+# inhe
+newProviderConfig = (otherProperties) ->
+  properties =
+    directionToOpen: inheritGlobalEnum('directionToOpen')
+    caseSensitivityForNarrowQuery: inheritGlobalEnum('caseSensitivityForNarrowQuery')
+    activateOnStart: inheritGlobalEnum('activateOnStart')
     revealOnStartCondition:
-      default: "on-input"
-  )
-  Symbols: newProviderConfig(
-    revealOnStartCondition:
-      default: "on-input"
-  )
-  ProjectSymbols: newProviderConfig(
-    revealOnStartCondition:
-      default: "on-input"
-  )
-  Linter: newProviderConfig()
-  Bookmarks: newProviderConfig()
+      default: 'always'
+      enum: ['always', 'never', 'on-input']
+    negateNarrowQueryByEndingExclamation: false
+    autoPreview: true
+    autoPreviewOnQueryChange: true
+    closeOnConfirm: true
+
+  _.deepExtend(properties, complimentField(otherProperties)) if otherProperties?
+
+  return {
+    type: 'object'
+    collapsed: true
+    properties: complimentField(properties, true)
+  }
+
+providerSettings =
   Scan: newProviderConfig(
-    revealOnStartCondition:
-      default: "on-input"
+    revealOnStartCondition: 'on-input'
     searchWholeWord:
       default: false
       description: """
-      This provider is exceptional since it use first query as scan term.<br>
-      You can toggle value per narrow-editor via `narrow-ui:toggle-search-whole-word`( `alt-cmd-w` )<br>
-      """
+        This provider is exceptional since it use first query as scan term.<br>
+        You can toggle value per narrow-editor via `narrow-ui:toggle-search-whole-word`( `alt-cmd-w` )<br>
+        """
     caseSensitivityForSearchTerm:
       default: 'smartcase'
       enum: ['smartcase', 'sensitive', 'insensitive']
-      description: """
-      Search term is first word of query, is used as search term
-      """
+      description: "Search term is first word of query, is used as search term"
   )
   Search: newProviderConfig(
     caseSensitivityForSearchTerm:
@@ -183,9 +153,9 @@ module.exports = new Settings 'narrow',
     startByDoubleClick:
       default: false
       description: """
-      [Experimental]: start by dounble click.
-      You can toggle this value by command `narrow:toggle-search-start-by-double-click`
-      """
+        [Experimental]: start by dounble click.
+        You can toggle this value by command `narrow:toggle-search-start-by-double-click`
+        """
   )
   AtomScan: newProviderConfig(
     caseSensitivityForSearchTerm:
@@ -195,15 +165,23 @@ module.exports = new Settings 'narrow',
     rememberIgnoreCaseForByCurrentWordSearch: false
     searchWholeWord: false
   )
+  Symbols: newProviderConfig(revealOnStartCondition: 'on-input')
+  GitDiffAll: newProviderConfig()
+  Fold: newProviderConfig(revealOnStartCondition: 'on-input')
+  ProjectSymbols: newProviderConfig(revealOnStartCondition: 'on-input')
+  Linter: newProviderConfig()
+  Bookmarks: newProviderConfig()
   GitDiff: newProviderConfig()
   SelectFiles: newProviderConfig(
     autoPreview: false
     autoPreviewOnQueryChange: false
     negateNarrowQueryByEndingExclamation: true
     closeOnConfirm: true
-    revealOnStartCondition:
-      default: 'never'
+    revealOnStartCondition: 'never'
     rememberQuery:
       default: false
       description: "Remember query per provider basis and apply it at startup"
   )
+
+
+module.exports = new Settings('narrow', _.defaults(globalSettings, providerSettings))

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -109,7 +109,7 @@ newProviderConfig = (otherProperties) ->
     focusOnStartCondition:
       default: 'always'
       description: "[Experiment] In-eval if this is really useful( I don't use this )"
-      enum: ['never', 'always', 'no-input']
+      enum: ['always', 'never', 'no-input']
     negateNarrowQueryByEndingExclamation: false
     autoPreview: true
     autoPreviewOnQueryChange: true
@@ -122,6 +122,22 @@ newProviderConfig = (otherProperties) ->
     collapsed: true
     properties: complimentField(properties, true)
   }
+
+newProviderConfigForSearchAndAtomScan = (otherProperties={}) ->
+  properties =
+    revealOnStartCondition:
+      default: 'always'
+      enum: ['always', 'never']
+    focusOnStartCondition:
+      default: 'always'
+      enum: ['always', 'never']
+    caseSensitivityForSearchTerm:
+      default: 'smartcase'
+      enum: ['smartcase', 'sensitive', 'insensitive']
+    rememberIgnoreCaseForByHandSearch: false
+    rememberIgnoreCaseForByCurrentWordSearch: false
+    searchWholeWord: false
+  newProviderConfig(_.extend(properties, otherProperties))
 
 providerSettings =
   Scan: newProviderConfig(
@@ -137,13 +153,7 @@ providerSettings =
       enum: ['smartcase', 'sensitive', 'insensitive']
       description: "Search term is first word of query, is used as search term"
   )
-  Search: newProviderConfig(
-    caseSensitivityForSearchTerm:
-      default: 'smartcase'
-      enum: ['smartcase', 'sensitive', 'insensitive']
-    rememberIgnoreCaseForByHandSearch: false
-    rememberIgnoreCaseForByCurrentWordSearch: false
-    searchWholeWord: false
+  Search: newProviderConfigForSearchAndAtomScan(
     searcher:
       default: 'ag'
       enum: ['ag', 'rg']
@@ -157,14 +167,7 @@ providerSettings =
         You can toggle this value by command `narrow:toggle-search-start-by-double-click`
         """
   )
-  AtomScan: newProviderConfig(
-    caseSensitivityForSearchTerm:
-      default: 'smartcase'
-      enum: ['smartcase', 'sensitive', 'insensitive']
-    rememberIgnoreCaseForByHandSearch: false
-    rememberIgnoreCaseForByCurrentWordSearch: false
-    searchWholeWord: false
-  )
+  AtomScan: newProviderConfigForSearchAndAtomScan()
   Symbols: newProviderConfig(revealOnStartCondition: 'on-input')
   GitDiffAll: newProviderConfig()
   Fold: newProviderConfig(revealOnStartCondition: 'on-input')

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -92,9 +92,6 @@ globalSettings =
     default: 'smartcase'
     enum: ['smartcase', 'sensitive', 'insensitive']
     description: "Case sensitivity of your query in narrow-editor"
-  activateOnStart:
-    default: 'always'
-    enum: ['never', 'always', 'on-input']
   confirmOnUpdateRealFile: true
 
 inheritGlobalEnum = (name) ->
@@ -106,10 +103,13 @@ newProviderConfig = (otherProperties) ->
   properties =
     directionToOpen: inheritGlobalEnum('directionToOpen')
     caseSensitivityForNarrowQuery: inheritGlobalEnum('caseSensitivityForNarrowQuery')
-    activateOnStart: inheritGlobalEnum('activateOnStart')
     revealOnStartCondition:
       default: 'always'
       enum: ['always', 'never', 'on-input']
+    focusOnStartCondition:
+      default: 'always'
+      description: "[Experiment] In-eval if this is really useful( I don't use this )"
+      enum: ['never', 'always', 'no-input']
     negateNarrowQueryByEndingExclamation: false
     autoPreview: true
     autoPreviewOnQueryChange: true

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -88,13 +88,16 @@ newProviderConfig = (otherProperties) ->
     caseSensitivityForNarrowQuery:
       default: 'inherit'
       enum: ['inherit', 'smartcase', 'sensitive', 'insensitive']
+    activateOnStart:
+      default: 'always'
+      enum: ['inherit', 'never', 'always', 'on-input']
     negateNarrowQueryByEndingExclamation: false
     autoPreview: true
     autoPreviewOnQueryChange: true
     closeOnConfirm: true
     revealOnStartCondition:
       default: 'always'
-      enum: ['never', 'always', 'on-input']
+      enum: ['inherit', 'never', 'always', 'on-input']
 
   _.deepExtend(properties, otherProperties) if otherProperties?
 
@@ -124,6 +127,10 @@ module.exports = new Settings 'narrow',
     default: 'smartcase'
     enum: ['smartcase', 'sensitive', 'insensitive']
     description: "Case sensitivity of your query in narrow-editor"
+
+  activateOnStart:
+    default: 'always'
+    enum: ['never', 'always', 'on-input']
 
   confirmOnUpdateRealFile: true
 

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -251,7 +251,9 @@ class Ui
     # So pane.activate must be called AFTER activateItem
     pane = @getPaneToOpen()
     pane.activateItem(@editor, {pending})
-    pane.activate()
+
+    if @provider.needActivateOnStart()
+      pane.activate()
 
     @grammar.activate()
     @setQuery(@query)
@@ -265,7 +267,7 @@ class Ui
     )
 
     @refresh().then =>
-      if @provider.needAutoReveal()
+      if @provider.needRevealOnStart()
         @syncToEditor(@provider.editor)
         @moveToBeginningOfSelectedItem()
         @preview()
@@ -585,9 +587,8 @@ class Ui
         @emitDidMoveToItemArea() if @isPromptRow(oldRow)
         @preview() if @autoPreview
 
-  # Return success or fail
   syncToEditor: (editor) ->
-    return false if @inPreview
+    return if @inPreview
 
     point = editor.getCursorBufferPosition()
     if @provider.boundToSingleFile
@@ -600,9 +601,6 @@ class Ui
       wasAtPrompt = @isAtPrompt()
       @moveToSelectedItem(scrollToColumnZero: true)
       @emitDidMoveToItemArea() if wasAtPrompt
-      true
-    else
-      false
 
   moveToSelectedItem: ({scrollToColumnZero, ignoreCursorMove, column}={}) ->
     return if (row = @items.getRowForSelectedItem()) is -1
@@ -622,6 +620,7 @@ class Ui
       moveAndScroll()
 
   preview: ->
+    return unless @isActive()
     return unless item = @items.getSelectedItem()
 
     @inPreview = true


### PR DESCRIPTION
Fix #177

- new config param `focusOnStartCondition`
- This config control whether initially focus to `narrow-editor` or not.
- Possible values are
  - `never`: never focus to `narrow-editor` on start.
  - `always`: always focus to `narrow-editor` on start( default ).
  - `no-input`: focus when initial query was empty( limitation: for `search`, `atom-scan` this value is not supported )

- This is very experimental feature, might be removed in future( after evaluated I found I myself don't need this ).
