### PR TITLE
faster scan

### DIFF
--- a/lib/provider/scan.coffee
+++ b/lib/provider/scan.coffee
@@ -23,12 +23,16 @@ class Scan extends ProviderBase
 
   scanEditor: (regexp) ->
     items = []
-    @editor.scan regexp, ({range}) =>
-      items.push({
-        text: @editor.lineTextForBufferRow(range.start.row)
-        point: range.start
-        range: range
-      })
+    regExp = new RegExp(regexp.source, regexp.flags) # clone to reset lastIndex
+    for lineText, row in @editor.buffer.getLines()
+      regExp.lastIndex = 0
+      while result = regExp.exec(lineText)
+        start = new Point(row, result.index)
+        items.push(
+          text: lineText
+          point: start
+          range: Range.fromPointWithDelta(start, 0, result[0].length)
+        )
     items
 
   getItems: ->


### PR DESCRIPTION
By NOT using `editor.scan`, `narrow:scan` get much faster.

## Steps to measure perf

1. open `text-editor.coffee` of atom-core's source
2. start `narrow:scan`
3. type initial char

Result for different initial char

```
scan:new:r: 8.806ms
scan:old:r: 29.064ms

scan:new:o: 8.588ms
scan:old:o: 18.918ms

scan:new:t: 10.766ms
scan:old:t: 30.820ms

scan:new:l: 4.183ms
scan:old:l: 28.233ms

scan:new:o: 4.252ms
scan:old:o: 14.475ms
```
