### PR TITLE
Support query history

### DIFF
--- a/keymaps/narrow.cson
+++ b/keymaps/narrow.cson
@@ -51,6 +51,7 @@
 
 'atom-text-editor.narrow.narrow-editor:not(.read-only)[data-grammar="source narrow"]':
   'escape': 'narrow-ui:stop-insert'
+  'ctrl-u': 'narrow-ui:delete-to-end-of-search-term'
 
 'atom-text-editor.narrow.narrow-editor.read-only[data-grammar="source narrow"]:not(.vim-mode-plus)':
   'k': 'core:move-up'

--- a/keymaps/narrow.cson
+++ b/keymaps/narrow.cson
@@ -9,6 +9,9 @@
   'ctrl-cmd-f': 'narrow:focus'
   'ctrl-cmd-p': 'narrow:previous-item'
   'ctrl-cmd-n': 'narrow:next-item'
+  'cmd-[': 'narrow:previous-query-history'
+  'cmd-]': 'narrow:next-query-history'
+  'cmd-e': 'narrow:next-query-history'
 
 # Only on narrow-editor
 # ---------------------------

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -60,6 +60,8 @@ module.exports =
       'narrow:close': => @getUi(skipProtected: true)?.close()
       'narrow:next-item': => @getUi()?.confirmItemForDirection('next')
       'narrow:previous-item': => @getUi()?.confirmItemForDirection('previous')
+      'narrow:next-query-history': => @getUi()?.setQueryFromHistroy('next')
+      'narrow:previous-query-history': => @getUi()?.setQueryFromHistroy('previous')
       'narrow:reopen': => @reopen()
       'narrow:query-current-word': => @getUi()?.queryCurrentWord()
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -9,8 +9,14 @@ ProviderBase = require "./provider/provider-base"
 module.exports =
   config: settings.config
   lastFocusedNarrowEditor: null
+  serialize: ->
+    {
+      queryHistory: Ui.queryHistory.serialize()
+    }
 
-  activate: ->
+  activate: (restoredState) ->
+    Ui.queryHistory.deserialize(restoredState.queryHistory)
+
     @subscriptions = subs = new CompositeDisposable
     settings.removeDeprecated()
 

--- a/lib/query-history.coffee
+++ b/lib/query-history.coffee
@@ -3,9 +3,8 @@ _ = require 'underscore-plus'
 
 class History
   maxSize: 100
-  constructor: ->
+  constructor: (@entries=[]) ->
     @index = -1
-    @entries = []
 
   get: (direction) ->
     switch direction
@@ -31,6 +30,16 @@ class QueryHistory
   constructor: ->
     @historyByProviderName = {}
 
+  deserialize: (state) ->
+    for name, entries of state ? {}
+      @historyByProviderName[name] = new History(entries)
+
+  serialize: ->
+    result = {}
+    for name, history of @historyByProviderName
+      result[name] = history.entries
+    result
+
   save: (name, value) ->
     @historyByProviderName[name] ?= new History()
     @historyByProviderName[name].save(value)
@@ -40,5 +49,8 @@ class QueryHistory
 
   reset: (name) ->
     @historyByProviderName[name]?.reset()
+
+  clear: (name) ->
+    @historyByProviderName[name]?.clear()
 
 module.exports = new QueryHistory

--- a/lib/query-history.coffee
+++ b/lib/query-history.coffee
@@ -1,0 +1,44 @@
+_ = require 'underscore-plus'
+{getValidIndexForList} = require './utils'
+
+class History
+  maxSize: 100
+  constructor: ->
+    @index = -1
+    @entries = []
+
+  get: (direction) ->
+    switch direction
+      when 'previous'
+        @index = getValidIndexForList(@entries, @index + 1)
+      when 'next'
+        @index = getValidIndexForList(@entries, @index - 1)
+    @entries[@index]
+
+  save: (text) ->
+    return unless text
+    @entries.unshift(text)
+    @entries = _.uniq(@entries, (entry) -> entry.toString())
+    @entries.splice(@maxSize) if @entries.length > @maxSize
+
+  reset: ->
+    @index = -1
+
+  destroy: ->
+    @entries = null
+
+class QueryHistory
+  constructor: ->
+    @historyByProviderName = {}
+
+  save: (name, value) ->
+    @historyByProviderName[name] ?= new History()
+    @historyByProviderName[name].save(value)
+
+  get: (name, direction) ->
+    @historyByProviderName[name]?.get(direction) ? ""
+
+  reset: (name) ->
+    @historyByProviderName[name]?.reset()
+
+module.exports = new QueryHistory

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -58,6 +58,8 @@ class Ui
       numbers.push(ui.titleNumber)
     Math.max(numbers...) + 1
 
+  @queryHistory: queryHistory
+
   autoPreview: null
   autoPreviewOnQueryChange: null
 
@@ -144,8 +146,9 @@ class Ui
       'narrow-ui:toggle-search-ignore-case': @toggleSearchIgnoreCase
       'narrow-ui:toggle-search-use-regex': @toggleSearchUseRegex
       'narrow-ui:delete-to-end-of-search-term': => @deleteToEndOfSearchTerm()
-      'narrow-ui:set-next-query': => @setQueryFromHistroy('next')
-      'narrow-ui:set-previous-query': => @setQueryFromHistroy('previous')
+      'narrow-ui:next-query-history': => @setQueryFromHistroy('next')
+      'narrow-ui:previous-query-history': => @setQueryFromQueryHistroy('previous')
+      'narrow-ui:clear-query-history': => @clearHistroy()
 
   setQueryFromHistroy: (direction, retry) ->
     if text = queryHistory.get(@provider.name, direction)
@@ -153,6 +156,9 @@ class Ui
         @setQueryFromHistroy(direction, true)
       else
         @setQuery(text)
+
+  clearHistroy: ->
+    queryHistory.clear(@provider.name)
 
   resetHistory: ->
     queryHistory.reset(@provider.name)

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -1,5 +1,3 @@
-{inspect} = require 'util'
-p = (args...) -> console.log inspect(args...)
 _ = require 'underscore-plus'
 path = require 'path'
 {Point, Range, CompositeDisposable, Disposable, Emitter} = require 'atom'

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,7 +1,6 @@
 path = require 'path'
 {Point} = require 'atom'
 _ = require 'underscore-plus'
-{inspect} = require 'util'
 
 getAdjacentPane = (basePane, which) ->
   return unless children = basePane.getParent().getChildren?()


### PR DESCRIPTION
Fix #180

- Duplicate text is not saved.
- Empty text is not saved.
- Timing of save is
  - `Ui::open`: to save query of `by-current-word`
  - `Ui::destroy`: to save interactive search term
  - `Ui::queryCurrentWord`: to save `query-current-word`.

# How to recall history?

- Through explicit command, example keymap is here.
- By scoping `narrow-editor.prompt`, this command keymap is effective only when cursor is at prompt row.

```coffeescript
'atom-text-editor.narrow.narrow-editor.prompt.vim-mode-plus.insert-mode[data-grammar="source narrow"]':
  'ctrl-p': 'narrow-ui:previous-query-history'
  'ctrl-n': 'narrow-ui:next-query-history'
```
