### PR TITLE
item can refresh on did stop changing for search

### DIFF
--- a/lib/provider/fold.coffee
+++ b/lib/provider/fold.coffee
@@ -18,6 +18,7 @@ class Fold extends ProviderBase
   showLineHeader: false
   foldLevel: 2
   supportCacheItems: true
+  refreshOnDidStopChanging: true
 
   initialize: ->
     atom.commands.add @ui.editorElement,

--- a/lib/provider/git-diff-all.coffee
+++ b/lib/provider/git-diff-all.coffee
@@ -22,6 +22,7 @@ getItemsForFilePath = (repo, filePath) ->
 
 module.exports =
 class GitDiffAll extends ProviderBase
+  refreshOnDidSave: true
 
   getItems: ->
     promises = []

--- a/lib/provider/project-symbols.coffee
+++ b/lib/provider/project-symbols.coffee
@@ -68,6 +68,7 @@ module.exports =
 class ProjectSymbols extends ProviderBase
   showLineHeader: false
   queryWordBoundaryOnByCurrentWordInvocation: true
+  refreshOnDidSave: true
 
   onBindEditor: ({newEditor}) ->
     # Refresh item.point in cachedItems for saved filePath.

--- a/lib/provider/scan.coffee
+++ b/lib/provider/scan.coffee
@@ -1,7 +1,6 @@
 {Point, Range} = require 'atom'
 {cloneRegExp} = require '../utils'
 ProviderBase = require './provider-base'
-SearchOptions = require '../search-options'
 
 module.exports =
 class Scan extends ProviderBase
@@ -12,24 +11,13 @@ class Scan extends ProviderBase
   showSearchOption: true
   supportCacheItems: true
   useFirstQueryAsSearchTerm: true
-
-  scanEditor: (regExp) ->
-    items = []
-    regExp = cloneRegExp(regExp)
-    for lineText, row in @editor.buffer.getLines()
-      regExp.lastIndex = 0
-      while match = regExp.exec(lineText)
-        range = new Range([row, match.index], [row, match.index + match[0].length])
-        items.push(text: lineText, point: range.start, range: range)
-        # Avoid infinite loop in zero length match when regExp is /^/
-        break unless match[0]
-    items
+  refreshOnDidStopChanging: true
 
   getItems: ->
     @updateSearchState()
     {searchRegex} = @searchOptions
     if searchRegex?
-      items = @scanEditor(searchRegex)
+      items = @scanItemsForEditor(@editor, searchRegex)
     else
       items = @editor.buffer.getLines().map (text, row) ->
         point = new Point(row, 0)

--- a/lib/provider/search.coffee
+++ b/lib/provider/search.coffee
@@ -13,6 +13,7 @@ class Search extends ProviderBase
   supportCacheItems: true
   useFirstQueryAsSearchTerm: true
   supportFilePathOnlyItemsUpdate: true
+  refreshOnDidStopChanging: true
 
   getState: ->
     @mergeState(super, {@projects})
@@ -26,7 +27,8 @@ class Search extends ProviderBase
 
   searchFilePath: (filePath) ->
     if atom.project.contains(filePath)
-      @searcher.searchFilePath(filePath, @updateItems, @finishUpdateItems)
+      @scanItemsForFilePath(filePath, @searchOptions.searchRegex).then (items) =>
+        @finishUpdateItems(items)
     else
       # When non project file was saved. We have nothing todo, so just return old @items.
       @finishUpdateItems([])
@@ -62,15 +64,15 @@ class Search extends ProviderBase
     @searcher = null
     super
 
-  getItems: (filePath) ->
+  getItems: (event) ->
     @searcher.cancel()
     @updateSearchState()
     @searcher.setCommand(@getConfig('searcher'))
     @ui.grammar.update()
 
     if @searchOptions.searchRegex?
-      if filePath
-        @searchFilePath(filePath)
+      if event.filePath?
+        @searchFilePath(event.filePath)
       else
         @search()
     else

--- a/lib/provider/symbols.coffee
+++ b/lib/provider/symbols.coffee
@@ -14,7 +14,7 @@ class Symbols extends ProviderBase
   boundToSingleFile: true
   showLineHeader: false
   queryWordBoundaryOnByCurrentWordInvocation: true
-  items: null
+  refreshOnDidSave: true
 
   onBindEditor: ({newEditor}) ->
     @items = null


### PR DESCRIPTION
#181

## Before this PR

- Refresh is called at following timing
  - `boundToSingleFile` providers: `onDidStopChanging` (e.g. scan, fold)
  - non `boundToSingleFile` providers: `onDidSave` (e.g. search, atom-scan)

## After this PR

- Refresh is called based on following props on provider
  - `refreshOnDidStopChanging`
  - `refreshOnDidSave`
- Each provider must explicitly set these props if they want to refresh on these event.
- `search`, `atom-scan` use `ProviderBase::scanItemsForEditor` to re-scan file filePath.
  - This method is same method which `scan` provider mainly use.
