### PR TITLE
make git-diff-all provider change aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.47.0:
+- New: #230 `narrow:git-diff-all` now aware of unsaved modification.
+  - Refresh items without explicit save.
+    - Old: items are refreshed on save( `editor.onDidSave` ).
+    - New: items are refreshed on modified( `editor.onDidStopChanging` ).
 # 0.46.1:
 - FIX: #227 `narrow:search-current-project-by-current-word` did not work correctly.
   - Always threw `Uncaught TypeError: dir.contains is not a function`. but no longer.

--- a/lib/provider/git-diff-all.js
+++ b/lib/provider/git-diff-all.js
@@ -31,10 +31,23 @@ async function getItemsForFilePath(repo, filePath) {
   }
 }
 
+// Borrowed from git-diff core pacakge.
+function repositoryForPath(filePath) {
+  const directories = atom.project.getDirectories()
+  for (let i = 0; i < directories.length; i++) {
+    const directory = directories[i]
+    if (filePath === directory.getPath() || directory.contains(filePath)) {
+      return atom.project.getRepositories()[i]
+    }
+  }
+}
+
 const providerConfig = {
-  refreshOnDidSave: true,
   showProjectHeader: true,
   showFileHeader: true,
+  supportCacheItems: true,
+  supportFilePathOnlyItemsUpdate: true,
+  refreshOnDidStopChanging: true,
 }
 
 class GitDiffAll extends ProviderBase {
@@ -43,18 +56,27 @@ class GitDiffAll extends ProviderBase {
     Object.assign(this, providerConfig)
   }
 
-  getItems() {
-    const promises = []
-    const repositories = atom.project.getRepositories().filter(repo => repo != null)
-
-    const updateItems = items => this.updateItems(_.compact(items))
-    for (const repo of repositories) {
-      for (const filePath of getModifiedFilePathsForRepository(repo)) {
-        const promise = getItemsForFilePath(repo, filePath).then(updateItems)
-        promises.push(promise)
+  getItems({filePath}) {
+    if (filePath) {
+      const repo = repositoryForPath(filePath)
+      if (repo) {
+        getItemsForFilePath(repo, filePath).then(this.finishUpdateItems)
+      } else {
+        this.finishUpdateItems([])
       }
+    } else {
+      const promises = []
+      const updateItems = items => this.updateItems(_.compact(items))
+
+      const repositories = atom.project.getRepositories().filter(repo => repo != null)
+      for (const repo of repositories) {
+        for (const filePath of getModifiedFilePathsForRepository(repo)) {
+          const promise = getItemsForFilePath(repo, filePath).then(updateItems)
+          promises.push(promise)
+        }
+      }
+      Promise.all(promises).then(() => this.finishUpdateItems())
     }
-    Promise.all(promises).then(() => this.finishUpdateItems())
   }
 }
 module.exports = GitDiffAll


### PR DESCRIPTION
refresh items list on text change, instead of on-save.

![remove-debug-print](https://user-images.githubusercontent.com/155205/27769189-690cf858-5f5f-11e7-9518-1981ccb477e3.gif)


## Use case


Why this is useful?

Typical scenario where this feat shines is
- When I adde dirty `console.log` in multiple place.
- I want to delete these one.
- I can use `git-dif-all` which shows `console.log` lines as long as important modification.
- I can filter by `console` then `tab`, delete-line, `tab`, delete-line till remove all the garbage debug print line.
