### PR TITLE
[CRITICAL] fix modified buffer state is ignored on directEdit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.49.0:
+- New: `narrow-ui:open-at-here` which open file at same pane of UI.
+  - `O` is mapped by default in `read-only` mode of UI.
+- Fix: unsaved-change-aware ability of `git-diff-all` was broken from v0.48.1. #234.
+  - Because I blindly use `TextBuffer.load` which just load fileContent from disk, so unsaved modification was just ignored.
+- Fix: unsaved-change was incorrectly ignored on `update-real-file` from v0.48.1 #234.
+  - This is same reason of `git-diff-all` bug I mentioned above.
+
 # 0.48.1:
 - Fix: `git-diff-all` and `update-real-file` no longer add temporally opened editor into workspace. #232.
 
@@ -9,8 +17,7 @@
 - Breaking: Provider `atom-scan` no longer support direct edit.
   - `atom-scan` use `workspace.scan` method internally, and it item truncate matched lineText to fit screen width.
   - Since `narrow:update-real-file` works by replacing whole line, this `workspace.scan`'s truncation doesn't work fit well.
-- Why I suppoted this feature for this provider is just because of my lack of understanding of this caveat.
-
+  - Why I supported this feature for this provider is just because of my lack of understanding of this caveat.
 
 # 0.47.0:
 - New: #230 `narrow:git-diff-all` now aware of unsaved modification.

--- a/lib/provider/git-diff-all.js
+++ b/lib/provider/git-diff-all.js
@@ -1,14 +1,11 @@
 "use babel"
 
-const {Point, TextBuffer} = require("atom")
+const {Point} = require("atom")
 const _ = require("underscore-plus")
 const ProviderBase = require("./provider-base")
 const path = require("path")
 const fs = require("fs-plus")
-const {
-  limitNumber,
-  getFirstCharacterPositionForBufferRow,
-} = require("../utils")
+const {limitNumber, getFirstCharacterPositionForBufferRow} = require("../utils")
 
 function getModifiedFilePathsForRepository(repository) {
   const filePaths = []
@@ -35,11 +32,13 @@ function itemForGitDiff(diff, {buffer, filePath}) {
 }
 
 async function getItemsForFilePath(repo, filePath) {
-  const buffer = await TextBuffer.load(filePath)
+  const existingBuffer = atom.project.findBufferForPath(filePath)
+  const buffer = existingBuffer || (await atom.project.buildBuffer(filePath))
   const diffs = repo.getLineDiffs(filePath, buffer.getText())
   // When file was completely new file, getLineDiffs return null, so need guard.
   const result = diffs ? diffs.map(diff => itemForGitDiff(diff, {buffer, filePath})) : []
-  buffer.destroy()
+  if (!existingBuffer) buffer.destroy()
+
   return result
 }
 

--- a/lib/provider/provider-base.js
+++ b/lib/provider/provider-base.js
@@ -391,7 +391,9 @@ class ProviderBase {
   }
 
   async applyChanges(filePath, changes) {
-    const buffer = await TextBuffer.load(filePath)
+    const existingBuffer = atom.project.findBufferForPath(filePath)
+    const buffer = existingBuffer || (await atom.project.buildBuffer(filePath))
+
     buffer.transact(() => {
       for (let {newText, item} of changes) {
         const range = buffer.rangeForRow(item.point.row)
@@ -402,7 +404,7 @@ class ProviderBase {
       }
     })
     await buffer.save()
-    buffer.destroy()
+    if (!existingBuffer) buffer.destroy()
   }
 
   // Helpers


### PR DESCRIPTION
This fix should be backported manually to atom-narrow for Atom-stable(v.1.18).

This is degradation introduced when I fixed #232 
In #232 I began to use `TextBuffer.load` which just load file from disk, so modified state of existing buffer is just ignored which was super **bad** when user trying to `update-real-file`.

Here is example situation

1. search `abc`, ui shows many items that matches `abc`.
2. modify some `abc` including line on some editor, then item list automatically be updated, since items are unsaved-change-aware(read from existing buffer for modified file).
3. modify items in `ui` directly and `update-real-file`. To mutate file content, I need buffer instance. Using `TextBuffer.load` means, load fileContent from disk, but here we should refer existing buffer content to respect unsaved modification on buffer.

Don’t use TextBuffer.load when existingBuffer exists.
Should respect existing buffer whenever it’s exists.