### PR TITLE
onDidChangeScrollTop can be recursively fired and freeze Atom

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -473,7 +473,11 @@ class Ui {
       this.editorElement.classList.add("prompt")
     })
 
-    this.editorElement.onDidChangeScrollTop(() => {
+    let lastScrollTop
+    this.editorElement.onDidChangeScrollTop(scrollTop => {
+      if (lastScrollTop === scrollTop) return
+
+      lastScrollTop = scrollTop
       this.highlighter.clearItemsHighlightOnNarrowEditor()
       this.highlighter.highlightItemsOnNarrowEditor(this.items.getVisibleItems(), this.filterSpec)
     })


### PR DESCRIPTION
Fix #239 

No sure when this issue started, maybe this was original behavior of Atom.
narrow didn't use onDidChangeScrollTop event before, since it's is now used for decoration narrow-editor highlight but it was done by grammar.

from Atom v1.19 , Atom support text decoration which allow foreground color change, and narrow starting to use this approach to highlight narrow-editor.

Anyway what was happened is

1. onDidChangeScrollTop was fired
2. clear highlight which eventually fire onDidChangeScrollTop with same value in some situation
3. loop between 1-2 which freeze Atom.

I didn't investigated why 2 is happened(IMO, event should not be fired with same scrollTop).


