### PR TITLE
Limit line width

### DIFF
--- a/lib/searcher.js
+++ b/lib/searcher.js
@@ -106,6 +106,7 @@ class Searcher {
   }
 
   getArgs() {
+    const MAX_LINE_WIDTH = '200'
     const args = ["--vimgrep"]
 
     const {searchRegex} = this.searchOptions
@@ -117,11 +118,13 @@ class Searcher {
 
     if (this.command === "ag") {
       args.push(searchRegex.source)
+      args.push("--width", MAX_LINE_WIDTH)
     } else if (this.command === "rg") {
       // See #176
       // rg doesn't show filePath on each line when search file was passed explicitly.
       // Following option make result-output consistent with `ag`.
-      args.push("-H", "--no-heading", "--regexp")
+      
+      args.push("-H", "--max-columns", MAX_LINE_WIDTH, "--no-heading", "--regexp")
       args.push(unescapeRegExpForRg(searchRegex.source))
     }
     return args


### PR DESCRIPTION
Hello!

This PR limit's search line width for ag and rg to 200 bytes. 

Use case:
All that minified js files hangs narrow(and any terminal) without any purpose. They should be considered as binary and unsearchable, but they are text.