### PR TITLE
Truncate long line

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,14 @@ Start it from command-palette or set keymap in `keymap.cson`.
 
 ###### `config.cson`
 
-```
+```coffeescript
   narrow:
     Search:
       startByDoubleClick: true
     SelectFiles:
       rememberQuery: true
     confirmOnUpdateRealFile: false
+    textToPrependOnTextTruncation: "!!" # shorter indicator when text was truncated.
 ```
 
 ###### `keymap.cson`

--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -1,6 +1,13 @@
 const {CompositeDisposable, Point, Range} = require("atom")
 
-const {getVisibleEditors, isNarrowEditor, cloneRegExp, isNormalItem, arrayForRange} = require("./utils")
+const {
+  getVisibleEditors,
+  isNarrowEditor,
+  cloneRegExp,
+  isNormalItem,
+  arrayForRange,
+  getPrefixedTextLengthInfo,
+} = require("./utils")
 
 module.exports = class Highlighter {
   constructor(ui) {
@@ -99,26 +106,24 @@ module.exports = class Highlighter {
       }
 
       // These variables are used to calculate offset for highlight
-      const lineHeaderLength = item._lineHeader ? item._lineHeader.length : 0
-      const truncationIndicatorLength = item._truncationIndicator ? item._truncationIndicator.length : 0
-      const skipLength = lineHeaderLength + truncationIndicatorLength
+      const {lineHeaderLength, truncationIndicatorLength, totalLength} = getPrefixedTextLengthInfo(item)
 
       // We can highlight searchTerm only for item with range.
       if (item.range) {
         let range = item.translateRange ? item.translateRange() : item.range
-        range = [[itemRow, range.start.column + skipLength], [itemRow, range.end.column + skipLength]]
+        range = [[itemRow, range.start.column + totalLength], [itemRow, range.end.column + totalLength]]
         this.markerLayers.searchTerm.markBufferRange(range, {invalidate: "inside"})
       }
 
       if (includeFilters) {
-        const lineText = this.ui.editor.lineTextForBufferRow(itemRow).slice(skipLength)
+        const lineText = this.ui.editor.lineTextForBufferRow(itemRow).slice(totalLength)
         for (const regex of includeFilters) {
           regex.lastIndex = 0
           let match
           while ((match = regex.exec(lineText))) {
             const matchText = match[0]
             if (!matchText) break // Avoid infinite loop in zero length match(in regex /^/)
-            const range = [[itemRow, match.index + skipLength], [itemRow, regex.lastIndex + skipLength]]
+            const range = [[itemRow, match.index + totalLength], [itemRow, regex.lastIndex + totalLength]]
             this.markerLayers.includeFilter.markBufferRange(range, {invalidate: "inside"})
           }
         }

--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -86,13 +86,6 @@ module.exports = class Highlighter {
   }
 
   highlightItemsOnNarrowEditor(items, filterSpec) {
-    const {
-      header: headerLayer,
-      searchTerm: searchTermLayer,
-      includeFilter: includeFilterLayer,
-      truncationIndicator: truncationIndicatorLayer,
-    } = this.markerLayers
-
     const includeFilters = filterSpec ? filterSpec.include.map(re => new RegExp(re.source, re.flags + "g")) : null
 
     let itemRow = this.ui.items.getRowForItem(items[0]) - 1
@@ -101,7 +94,7 @@ module.exports = class Highlighter {
 
       if (item.header) {
         const range = this.ui.editor.bufferRangeForBufferRow(itemRow)
-        headerLayer.markBufferRange(range, {invalidate: "inside"})
+        this.markerLayers.header.markBufferRange(range, {invalidate: "inside"})
         continue
       }
 
@@ -114,7 +107,7 @@ module.exports = class Highlighter {
       if (item.range) {
         let range = item.translateRange ? item.translateRange() : item.range
         range = [[itemRow, range.start.column + skipLength], [itemRow, range.end.column + skipLength]]
-        searchTermLayer.markBufferRange(range, {invalidate: "inside"})
+        this.markerLayers.searchTerm.markBufferRange(range, {invalidate: "inside"})
       }
 
       if (includeFilters) {
@@ -126,14 +119,14 @@ module.exports = class Highlighter {
             const matchText = match[0]
             if (!matchText) break // Avoid infinite loop in zero length match(in regex /^/)
             const range = [[itemRow, match.index + skipLength], [itemRow, regex.lastIndex + skipLength]]
-            includeFilterLayer.markBufferRange(range, {invalidate: "inside"})
+            this.markerLayers.includeFilter.markBufferRange(range, {invalidate: "inside"})
           }
         }
       }
 
       if (truncationIndicatorLength) {
         const range = [[itemRow, lineHeaderLength], [itemRow, lineHeaderLength + truncationIndicatorLength]]
-        truncationIndicatorLayer.markBufferRange(range, {invalidate: "inside"})
+        this.markerLayers.truncationIndicator.markBufferRange(range, {invalidate: "inside"})
       }
     }
   }

--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -23,6 +23,7 @@ module.exports = class Highlighter {
     this.createMarkerLayer("searchTerm", "search-term")
     this.createMarkerLayer("searchTermForPrompt", "search-term")
     this.createMarkerLayer("includeFilter", "include-filter")
+    this.createMarkerLayer("truncationIndicator", "truncation-indicator")
     this.createMarkerLayer("includeFilterForPrompt", "include-filter")
     this.createMarkerLayer("excludeFilterForPrompt", "exclude-filter")
     this.createMarkerLayer("header", "header")
@@ -50,7 +51,7 @@ module.exports = class Highlighter {
     const markerLayer = editor.addMarkerLayer()
     const decorationLayer = editor.decorateMarkerLayer(markerLayer, {
       type: "text",
-      class: "narrow-syntax-" + className,
+      class: "narrow-syntax--" + className,
     })
     this.markerLayers[layerName] = markerLayer
     this.decorationLayers[layerName] = decorationLayer
@@ -81,10 +82,23 @@ module.exports = class Highlighter {
     this.markerLayers.header.clear()
     this.markerLayers.searchTerm.clear()
     this.markerLayers.includeFilter.clear()
+    this.markerLayers.truncationIndicator.clear()
+  }
+
+  getLineHeaderLengthForItem(item) {
+    return item._lineHeader ? item._lineHeader.length : 0
+  }
+  getTruncationIndicatorLengthForItem(item) {
+    return item._truncationIndicator ? item._truncationIndicator.length : 0
   }
 
   highlightItemsOnNarrowEditor(items, filterSpec) {
-    const {header: headerLayer, searchTerm: searchTermLayer, includeFilter: includeFilterLayer} = this.markerLayers
+    const {
+      header: headerLayer,
+      searchTerm: searchTermLayer,
+      includeFilter: includeFilterLayer,
+      truncationIndicator: truncationIndicatorLayer,
+    } = this.markerLayers
 
     const includeFilters = filterSpec ? filterSpec.include.map(re => new RegExp(re.source, re.flags + "g")) : null
 
@@ -98,25 +112,35 @@ module.exports = class Highlighter {
         continue
       }
 
+      // These variables are used to calculate offset for highlight
+      const lineHeaderLength = item._lineHeader ? item._lineHeader.length : 0
+      const truncationIndicatorLength = item._truncationIndicator ? item._truncationIndicator.length : 0
+      const skipLength = lineHeaderLength + truncationIndicatorLength
+
+      // We can highlight searchTerm only for item with range.
       if (item.range) {
         let range = item.translateRange ? item.translateRange() : item.range
-        const {start, end} = item._lineHeader ? range.translate([0, item._lineHeader.length]) : range
-        range = [[itemRow, start.column], [itemRow, end.column]]
+        range = [[itemRow, range.start.column + skipLength], [itemRow, range.end.column + skipLength]]
         searchTermLayer.markBufferRange(range, {invalidate: "inside"})
       }
 
       if (includeFilters) {
-        const lineText = this.ui.editor.lineTextForBufferRow(itemRow)
+        const lineText = this.ui.editor.lineTextForBufferRow(itemRow).slice(skipLength)
         for (const regex of includeFilters) {
           regex.lastIndex = 0
           let match
           while ((match = regex.exec(lineText))) {
             const matchText = match[0]
             if (!matchText) break // Avoid infinite loop in zero length match(in regex /^/)
-            const range = [[itemRow, match.index], [itemRow, regex.lastIndex]]
+            const range = [[itemRow, match.index + skipLength], [itemRow, regex.lastIndex + skipLength]]
             includeFilterLayer.markBufferRange(range, {invalidate: "inside"})
           }
         }
+      }
+
+      if (truncationIndicatorLength) {
+        const range = [[itemRow, lineHeaderLength], [itemRow, lineHeaderLength + truncationIndicatorLength]]
+        truncationIndicatorLayer.markBufferRange(range, {invalidate: "inside"})
       }
     }
   }

--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -85,13 +85,6 @@ module.exports = class Highlighter {
     this.markerLayers.truncationIndicator.clear()
   }
 
-  getLineHeaderLengthForItem(item) {
-    return item._lineHeader ? item._lineHeader.length : 0
-  }
-  getTruncationIndicatorLengthForItem(item) {
-    return item._truncationIndicator ? item._truncationIndicator.length : 0
-  }
-
   highlightItemsOnNarrowEditor(items, filterSpec) {
     const {
       header: headerLayer,

--- a/lib/items.js
+++ b/lib/items.js
@@ -16,7 +16,7 @@ class Items {
     this.cachedItems = null
 
     this.ui = ui
-    this.promptItem = Object.freeze({_prompt: true, skip: true})
+    this.promptItem = Object.freeze({_prompt: true, skip: true, _uiRow: 0})
     this.emitter = new Emitter()
     this.items = []
   }
@@ -34,7 +34,12 @@ class Items {
   }
 
   addItems(items) {
-    items.map(item => this.items.push(item))
+    let index = this.items.length
+    for (const item of items) {
+      item._uiRow = index
+      this.items[index] = item
+      index++
+    }
     this.selectedItem = null
     this.previouslySelectedItem = null
   }
@@ -104,7 +109,7 @@ class Items {
   }
 
   getRowForItem(item) {
-    return this.items.indexOf(item)
+    return item ? item._uiRow : -1
   }
 
   getItemForRow(row) {

--- a/lib/provider/provider-base.js
+++ b/lib/provider/provider-base.js
@@ -27,6 +27,9 @@ const settings = require("../settings")
 const FilterSpec = require("../filter-spec")
 const SearchOptions = require("../search-options")
 
+const ITEM_TRUNCATION_LENGTH = 200
+const ITEM_TRUNCATION_INDICATOR = "[truncated] "
+
 const providerConfig = {
   needRestoreEditorState: true,
   boundToSingleFile: false,
@@ -372,7 +375,13 @@ class ProviderBase {
     if (item.header) {
       return item.header
     } else {
-      return (item._lineHeader || "") + item.text
+      if (item.text.length > ITEM_TRUNCATION_LENGTH) {
+        text = ITEM_TRUNCATION_INDICATOR + item.text.slice(0, ITEM_TRUNCATION_LENGTH)
+        item._truncationIndicator = ITEM_TRUNCATION_INDICATOR // give hint to ui.highlighter
+      } else {
+        text = item.text
+      }
+      return (item._lineHeader || "") + text
     }
   }
 

--- a/lib/provider/provider-base.js
+++ b/lib/provider/provider-base.js
@@ -27,9 +27,6 @@ const settings = require("../settings")
 const FilterSpec = require("../filter-spec")
 const SearchOptions = require("../search-options")
 
-const ITEM_TRUNCATION_LENGTH = 200
-const ITEM_TRUNCATION_INDICATOR = "[truncated] "
-
 const providerConfig = {
   needRestoreEditorState: true,
   boundToSingleFile: false,
@@ -375,9 +372,11 @@ class ProviderBase {
     if (item.header) {
       return item.header
     } else {
-      if (item.text.length > ITEM_TRUNCATION_LENGTH) {
-        text = ITEM_TRUNCATION_INDICATOR + item.text.slice(0, ITEM_TRUNCATION_LENGTH)
-        item._truncationIndicator = ITEM_TRUNCATION_INDICATOR // give hint to ui.highlighter
+      const maxLength = settings.get("maxTextLengthToDisplay")
+      if (item.text.length > maxLength) {
+        const indicator = settings.get("textTruncationIndicator") + " "
+        text = indicator + item.text.slice(0, maxLength)
+        item._truncationIndicator = indicator // give hint to ui.highlighter
       } else {
         text = item.text
       }

--- a/lib/provider/provider-base.js
+++ b/lib/provider/provider-base.js
@@ -372,11 +372,11 @@ class ProviderBase {
     if (item.header) {
       return item.header
     } else {
-      const maxLength = settings.get("maxTextLengthToDisplay")
-      if (item.text.length > maxLength) {
-        const indicator = settings.get("textTruncationIndicator") + " "
-        text = indicator + item.text.slice(0, maxLength)
-        item._truncationIndicator = indicator // give hint to ui.highlighter
+      const threshold = settings.get("textTruncationThreshold")
+      if (item.text.length > threshold) {
+        const textToPrepend = settings.get("textToPrependOnTextTruncation") + " "
+        text = textToPrepend + item.text.slice(0, threshold)
+        item._truncationIndicator = textToPrepend // give hint to ui.highlighter
       } else {
         text = item.text
       }

--- a/lib/provider/provider-base.js
+++ b/lib/provider/provider-base.js
@@ -375,8 +375,10 @@ class ProviderBase {
       const threshold = settings.get("textTruncationThreshold")
       if (item.text.length > threshold) {
         const textToPrepend = settings.get("textToPrependOnTextTruncation") + " "
-        text = textToPrepend + item.text.slice(0, threshold)
+        const textDisplayed = item.text.slice(0, threshold)
         item._truncationIndicator = textToPrepend // give hint to ui.highlighter
+        item._textDisplayed = textDisplayed
+        text = textToPrepend + textDisplayed
       } else {
         text = item.text
       }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -33,6 +33,11 @@ const globalSettings = {
   },
   confirmOnUpdateRealFile: true,
   queryCurrentWordByDoubleClick: true,
+  maxTextLengthToDisplay: {
+    default: 200,
+    description: "Text exceeds this length is truncated and `textTruncationIndicator` is **prepended* to make truncated item standout",
+  },
+  textTruncationIndicator: "[truncated]",
 }
 
 const ProviderConfigTemplate = {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -33,12 +33,14 @@ const globalSettings = {
   },
   confirmOnUpdateRealFile: true,
   queryCurrentWordByDoubleClick: true,
-  maxTextLengthToDisplay: {
+  textTruncationThreshold: {
     default: 200,
-    description: "Text exceeds this length is truncated and `textTruncationIndicator` is **prepended* to make truncated item standout",
+    description: "Text exceeds this length is truncated and `textToPrependOnTextTruncation` is **prepended* to make truncated item standout",
   },
-  textTruncationIndicator: "[truncated]",
+  textToPrependOnTextTruncation: {
+    default: "[truncated]",
     description: "When item text was truncated, this text is prepended to standout trancated item.",
+  },
 }
 
 const ProviderConfigTemplate = {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -38,6 +38,7 @@ const globalSettings = {
     description: "Text exceeds this length is truncated and `textTruncationIndicator` is **prepended* to make truncated item standout",
   },
   textTruncationIndicator: "[truncated]",
+    description: "When item text was truncated, this text is prepended to standout trancated item.",
 }
 
 const ProviderConfigTemplate = {

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -434,12 +434,12 @@ class Ui {
 
     this.reducers = [
       itemReducer.spliceItemsForFilePath,
-      this.showLineHeader ? itemReducer.injectLineHeader : undefined,
+      this.showLineHeader && itemReducer.injectLineHeader,
       itemReducer.collectAllItems,
       itemReducer.filterFilePath,
       itemReducer.filterItems,
-      this.showProjectHeader ? itemReducer.insertProjectHeader : undefined,
-      this.showFileHeader ? itemReducer.insertFileHeader : undefined,
+      this.showProjectHeader && itemReducer.insertProjectHeader,
+      this.showFileHeader && itemReducer.insertFileHeader,
       this.renderItems,
     ].filter(reducer => reducer)
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -11,6 +11,8 @@ const {
   setBufferRow,
   paneForItem,
   isDefinedAndEqual,
+  ensurePrefixedTextAreNotMutated,
+  ensureNoTruncatedItemInChanges,
   ensureNoConflictForChanges,
   isNormalItem,
   cloneRegExp,
@@ -1390,13 +1392,13 @@ class Ui {
 
     if (this.editorLastRow !== this.editor.getLastBufferRow()) return
 
-    // Ensure all item have valid line header
-    if (this.showLineHeader) {
-      const itemHaveOriginalLineHeader = item => {
-        return this.editor.lineTextForBufferRow(this.items.getRowForItem(item)).startsWith(item._lineHeader)
+    // Ensure prefixed text(lineHeader + truncationIndicator) are NOT mutated.
+    {
+      const {success, message} = ensurePrefixedTextAreNotMutated(this)
+      if (!success) {
+        atom.notifications.addWarning(message, {dismissable: true})
+        return
       }
-
-      if (!this.items.getNormalItems().every(itemHaveOriginalLineHeader)) return
     }
 
     const changes = []
@@ -1404,19 +1406,34 @@ class Ui {
     for (let row = 0; row < lines.length; row++) {
       const item = this.items.getItemForRow(row)
       if (!isNormalItem(item)) continue
-      const lineHeaderEnd = item._lineHeader != null ? item._lineHeader.length : 0
-      const line = lines[row].slice(lineHeaderEnd)
-      if (line !== item.text) {
+
+      const lineHeaderLength = item._lineHeader ? item._lineHeader.length : 0
+      const truncationIndicatorLength = item._truncationIndicator ? item._truncationIndicator.length : 0
+      const skipLength = lineHeaderLength + truncationIndicatorLength
+
+      const line = lines[row].slice(skipLength)
+      const textToCompare = item._textDisplayed || item.text
+      if (line !== textToCompare) {
         changes.push({newText: line, item})
       }
     }
 
     if (!changes.length) return
 
-    const {success, message} = ensureNoConflictForChanges(changes)
-    if (!success) {
-      atom.notifications.addWarning(message, {dismissable: true})
-      return
+    {
+      const {success, message} = ensureNoTruncatedItemInChanges(changes)
+      if (!success) {
+        atom.notifications.addWarning(message, {dismissable: true})
+        return
+      }
+    }
+
+    {
+      const {success, message} = ensureNoConflictForChanges(changes)
+      if (!success) {
+        atom.notifications.addWarning(message, {dismissable: true})
+        return
+      }
     }
 
     await this.provider.updateRealFile(changes)

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -11,9 +11,6 @@ const {
   setBufferRow,
   paneForItem,
   isDefinedAndEqual,
-  ensurePrefixedTextAreNotMutated,
-  ensureNoTruncatedItemInChanges,
-  ensureNoConflictForChanges,
   isNormalItem,
   cloneRegExp,
   suppressEvent,
@@ -30,7 +27,7 @@ const Items = require("./items")
 const ItemIndicator = require("./item-indicator")
 const queryHistory = require("./query-history")
 
-let SelectFiles = null
+let SelectFiles, updateRealFile
 
 class Ui {
   static initClass() {
@@ -1381,63 +1378,9 @@ class Ui {
 
   // Direct-edit related
   // -------------------------
-  async updateRealFile() {
-    if (!this.supportDirectEdit) return
-    if (!this.isModified()) return
-
-    if (settings.get("confirmOnUpdateRealFile")) {
-      const options = {message: "Update real file?", buttons: ["Update", "Cancel"]}
-      if (atom.confirm(options) !== 0) return
-    }
-
-    if (this.editorLastRow !== this.editor.getLastBufferRow()) return
-
-    // Ensure prefixed text(lineHeader + truncationIndicator) are NOT mutated.
-    {
-      const {success, message} = ensurePrefixedTextAreNotMutated(this)
-      if (!success) {
-        atom.notifications.addWarning(message, {dismissable: true})
-        return
-      }
-    }
-
-    const changes = []
-    const lines = this.editor.buffer.getLines()
-    for (let row = 0; row < lines.length; row++) {
-      const item = this.items.getItemForRow(row)
-      if (!isNormalItem(item)) continue
-
-      const lineHeaderLength = item._lineHeader ? item._lineHeader.length : 0
-      const truncationIndicatorLength = item._truncationIndicator ? item._truncationIndicator.length : 0
-      const skipLength = lineHeaderLength + truncationIndicatorLength
-
-      const line = lines[row].slice(skipLength)
-      const textToCompare = item._textDisplayed || item.text
-      if (line !== textToCompare) {
-        changes.push({newText: line, item})
-      }
-    }
-
-    if (!changes.length) return
-
-    {
-      const {success, message} = ensureNoTruncatedItemInChanges(changes)
-      if (!success) {
-        atom.notifications.addWarning(message, {dismissable: true})
-        return
-      }
-    }
-
-    {
-      const {success, message} = ensureNoConflictForChanges(changes)
-      if (!success) {
-        atom.notifications.addWarning(message, {dismissable: true})
-        return
-      }
-    }
-
-    await this.provider.updateRealFile(changes)
-    this.setModifiedState(false)
+  updateRealFile() {
+    if (!updateRealFile) updateRealFile = require("./update-real-file")
+    return updateRealFile(this)
   }
 }
 Ui.initClass()

--- a/lib/update-real-file.js
+++ b/lib/update-real-file.js
@@ -1,0 +1,97 @@
+"use babel"
+
+const settings = require("./settings")
+const {isNormalItem, getPrefixedTextLengthInfo} = require("./utils")
+const _ = require("underscore-plus")
+
+function warn(message) {
+  atom.notifications.addWarning("Cancelled `update-real-file`.<br>" + message, {dismissable: true})
+}
+
+// Ensure prefixed text(lineHeader + truncationIndicator) are NOT mutated.
+function ensurePrefixedTextAreNotMutated(ui) {
+  const prefixedTextFor = item => (item._lineHeader || "") + (item._truncationIndicator || "")
+  const uiTextFor = item => ui.editor.lineTextForBufferRow(item._uiRow)
+  const success = ui.items.getNormalItems().every(item => uiTextFor(item).startsWith(prefixedTextFor(item)))
+  if (!success) warn("Line header or truncation indicator was mutated.")
+  return success
+}
+
+function ensureNoTruncatedItemInChanges(changes) {
+  const success = changes.every(change => !change.item._truncationIndicator)
+  if (!success) warn("You cannot directly update **truncated** text.")
+  return success
+}
+
+// detect conflicting change
+function ensureNoConflictForChanges(changes) {
+  const message = []
+  const conflictChanges = detectConflictForChanges(changes)
+  const success = _.isEmpty(conflictChanges)
+  if (!success) {
+    message.push("Detected **conflicting change to same line**.")
+    for (const filePath in conflictChanges) {
+      const changesInFile = conflictChanges[filePath]
+      message.push(`- ${filePath}`)
+      for (let {newText, item} of changesInFile) {
+        message.push(`  - ${item.point.translate([1, 1]).toString()}, ${newText}`)
+      }
+    }
+    warn(message.join("\n"))
+  }
+  return success
+}
+
+function detectConflictForChanges(changes) {
+  const conflictChanges = {}
+  const changesByFilePath = _.groupBy(changes, ({item}) => item.filePath)
+  for (let filePath in changesByFilePath) {
+    const changesInFile = changesByFilePath[filePath]
+    const changesByRow = _.groupBy(changesInFile, ({item}) => item.point.row)
+    for (let row in changesByRow) {
+      const changesInRow = changesByRow[row]
+      const newTexts = _.pluck(changesInRow, "newText")
+      if (_.uniq(newTexts).length > 1) {
+        if (conflictChanges[filePath] == null) {
+          conflictChanges[filePath] = []
+        }
+        conflictChanges[filePath].push(...(changesInRow || []))
+      }
+    }
+  }
+  return conflictChanges
+}
+
+module.exports = async function updateRealFile(ui) {
+  if (!ui.supportDirectEdit) return
+  if (!ui.isModified()) return
+
+  if (settings.get("confirmOnUpdateRealFile")) {
+    const options = {message: "Update real file?", buttons: ["Update", "Cancel"]}
+    if (atom.confirm(options) !== 0) return
+  }
+
+  if (ui.editorLastRow !== ui.editor.getLastBufferRow()) return
+
+  if (!ensurePrefixedTextAreNotMutated(ui)) return
+
+  const changes = []
+  const lines = ui.editor.buffer.getLines()
+
+  for (let row = 0; row < lines.length; row++) {
+    const item = ui.items.getItemForRow(row)
+    if (!isNormalItem(item)) continue
+    const line = lines[row].slice(getPrefixedTextLengthInfo(item).totalLength)
+    const textToCompare = item._textDisplayed || item.text
+    if (line !== textToCompare) {
+      changes.push({newText: line, item})
+    }
+  }
+
+  if (!changes.length) return
+
+  if (!ensureNoTruncatedItemInChanges(changes)) return
+  if (!ensureNoConflictForChanges(changes)) return
+  await ui.provider.updateRealFile(changes)
+  ui.setModifiedState(false)
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -164,66 +164,6 @@ function getModifiedFilePathsInChanges(changes) {
   return changes.map(toFilePath).filter(isModified)
 }
 
-function ensurePrefixedTextAreNotMutated(ui) {
-  const itemStartsWithPrefixedText = item => {
-    const prefixedText = (item._lineHeader || "") + (item._truncationIndicator || "")
-    const itemRow = ui.items.getRowForItem(item)
-    return ui.editor.lineTextForBufferRow(itemRow).startsWith(prefixedText)
-  }
-
-  const normalItems = ui.items.getNormalItems()
-  const success = normalItems.every(itemStartsWithPrefixedText)
-  const message = !success ? "Cancelled `update-real-file`.\nLine header or truncation indicator was mutated." : ""
-  return {success, message}
-}
-
-function ensureNoTruncatedItemInChanges(changes) {
-  const success = changes.every(change => !change.item._truncationIndicator)
-  const message = !success ? "Cancelled `update-real-file`.\nYou cannot directly update text-truncated item." : ""
-  return {success, message}
-}
-
-// detect conflicting change
-function ensureNoConflictForChanges(changes) {
-  const message = []
-  const conflictChanges = detectConflictForChanges(changes)
-  const success = _.isEmpty(conflictChanges)
-  if (!success) {
-    message.push("Cancelled `update-real-file`.")
-    message.push("Detected **conflicting change to same line**.")
-    for (const filePath in conflictChanges) {
-      const changesInFile = conflictChanges[filePath]
-      message.push(`- ${filePath}`)
-      for (let {newText, item} of changesInFile) {
-        message.push(`  - ${item.point.translate([1, 1]).toString()}, ${newText}`)
-      }
-    }
-  }
-
-  return {success, message: message.join("\n")}
-}
-
-function detectConflictForChanges(changes) {
-  const conflictChanges = {}
-  const changesByFilePath = _.groupBy(changes, ({item}) => item.filePath)
-  for (let filePath in changesByFilePath) {
-    const changesInFile = changesByFilePath[filePath]
-    const changesByRow = _.groupBy(changesInFile, ({item}) => item.point.row)
-    for (let row in changesByRow) {
-      const changesInRow = changesByRow[row]
-      const newTexts = _.pluck(changesInRow, "newText")
-      if (_.uniq(newTexts).length > 1) {
-        if (conflictChanges[filePath] == null) {
-          conflictChanges[filePath] = []
-        }
-        conflictChanges[filePath].push(...Array.from(changesInRow || []))
-      }
-    }
-  }
-  return conflictChanges
-}
-
-//
 // item utils
 // -------------------------
 function isNormalItem(item) {
@@ -374,9 +314,6 @@ module.exports = {
   cloneRegExp,
   addToolTips,
 
-  ensurePrefixedTextAreNotMutated,
-  ensureNoTruncatedItemInChanges,
-  ensureNoConflictForChanges,
   isNormalItem,
   getPrefixedTextLengthInfo,
   compareByPoint,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -164,6 +164,25 @@ function getModifiedFilePathsInChanges(changes) {
   return changes.map(toFilePath).filter(isModified)
 }
 
+function ensurePrefixedTextAreNotMutated(ui) {
+  const itemStartsWithPrefixedText = item => {
+    const prefixedText = (item._lineHeader || "") + (item._truncationIndicator || "")
+    const itemRow = ui.items.getRowForItem(item)
+    return ui.editor.lineTextForBufferRow(itemRow).startsWith(prefixedText)
+  }
+
+  const normalItems = ui.items.getNormalItems()
+  const success = normalItems.every(itemStartsWithPrefixedText)
+  const message = !success ? "Cancelled `update-real-file`.\nLine header or truncation indicator was mutated." : ""
+  return {success, message}
+}
+
+function ensureNoTruncatedItemInChanges(changes) {
+  const success = changes.every(change => !change.item._truncationIndicator)
+  const message = !success ? "Cancelled `update-real-file`.\nYou cannot directly update text-truncated item." : ""
+  return {success, message}
+}
+
 // detect conflicting change
 function ensureNoConflictForChanges(changes) {
   const message = []
@@ -347,6 +366,8 @@ module.exports = {
   cloneRegExp,
   addToolTips,
 
+  ensurePrefixedTextAreNotMutated,
+  ensureNoTruncatedItemInChanges,
   ensureNoConflictForChanges,
   isNormalItem,
   compareByPoint,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -230,6 +230,14 @@ function isNormalItem(item) {
   return item != null && !item.skip
 }
 
+function getPrefixedTextLengthInfo(item) {
+  const lineHeaderLength = item._lineHeader ? item._lineHeader.length : 0
+  const truncationIndicatorLength = item._truncationIndicator ? item._truncationIndicator.length : 0
+  const totalLength = lineHeaderLength + truncationIndicatorLength
+
+  return {lineHeaderLength, truncationIndicatorLength, totalLength}
+}
+
 function compareByPoint(a, b) {
   return a.point.compare(b.point)
 }
@@ -370,6 +378,7 @@ module.exports = {
   ensureNoTruncatedItemInChanges,
   ensureNoConflictForChanges,
   isNormalItem,
+  getPrefixedTextLengthInfo,
   compareByPoint,
   getProjectPaths,
   suppressEvent,

--- a/styles/narrow.less
+++ b/styles/narrow.less
@@ -72,16 +72,19 @@ atom-text-editor {
 .flash-animation(narrow-editor-cursor-line-flash-long, @flash-color);
 
 atom-text-editor {
-  .narrow-syntax-search-term {
+  .narrow-syntax--search-term {
     color: @syntax-color-function !important;
   }
-  .narrow-syntax-include-filter {
+  .narrow-syntax--include-filter {
     color: @syntax-color-keyword;
   }
-  .narrow-syntax-exclude-filter {
+  .narrow-syntax--exclude-filter {
     color: @syntax-color-removed;
   }
-  .narrow-syntax-header {
+  .narrow-syntax--truncation-indicator {
+    color: @syntax-color-removed;
+  }
+  .narrow-syntax--header {
     color: @syntax-color-variable;
   }
 


### PR DESCRIPTION
Alternate approach for #242

Truncate long line by narrow itself instead of doing truncation at searcher(`ag`, `rg`) level.

# TODO

- [x] Truncate long line on rendering timing
  - This is super important. It's **after** item gathering/filtering phase.
- [x] Make limit length configurable(default `200`?). `textTruncationThreshold`
- [x] Make indicator configurable.l(default `[truncated]`). `textToPrependOnTextTruncation`, I use `!!` locally.
- [x] highlight truncation indicator on narrow-editor.(red color).
- [x] Protect on direct-edit(`update-real-file`): disallow replacing line on disk with truncated-item's line.
  - Even if there were truncated item on narrow-editor, as long as it's not used for updating, should that operation allowed.
  - So validate very last timing that items to update not including truncated-item.
- [x] Refactoring/cleanup