### PR TITLE
Use narrow:close instead of core:close

### DIFF
--- a/keymaps/narrow.cson
+++ b/keymaps/narrow.cson
@@ -40,7 +40,7 @@
 'atom-text-editor.narrow.narrow-editor.read-only[data-grammar="source narrow"],
   atom-text-editor.narrow.narrow-editor.vim-mode-plus.normal-mode[data-grammar="source narrow"]':
     'enter': 'core:confirm'
-    'q': 'core:close'
+    'q': 'narrow:close'
     'o': 'narrow-ui:confirm-keep-open'
     'O': 'narrow-ui:open-here'
     'r': 'narrow-ui:toggle-auto-preview'


### PR DESCRIPTION
Use `narrow:close` as the default behavior of quit. 

I am not sure if this is a mistake or intent. If it is an intent, please feel free to reject this PR. 

btw, I really enjoy `narrow`. 👍 