### PR TITLE
Fix utils.getProjectPaths causing breakage in 'search-current-project-by-current word'

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -213,7 +213,7 @@ function getProjectPaths(editor) {
   const filePath = editor.getPath()
   if (filePath) {
     const dir = atom.project.getDirectories().find(dir => dir.contains(filePath))
-    if (dir) return [dir.getPaths()]
+    if (dir) return [dir.getPath()]
   }
   atom.notifications.addInfo("This file is not belonging to any project", {dismissable: true})
 }


### PR DESCRIPTION
The method got changed from `dir.getPath()` to `dir.getPaths()` at e9ce92d9512d84e74d11a50de07f07f72c20b277, which broke 'search-current-project-by-current word' for me.

Locally, changing it back to `dir.getPath()` appear to fix it.