### PR TITLE
Provider git diff all use inline git diff service

### DIFF
--- a/lib/control-bar.js
+++ b/lib/control-bar.js
@@ -10,6 +10,7 @@ class ControlBar {
       <div class='base inline-block'>
         <a class='auto-preview'></a>
         <span class='provider-name'>${this.ui.provider.dashName}</span>
+        <a class='inline-git-diff'></a>
         <span class='item-count'>0</span>
         <a class='refresh'></a>
         <a class='protected'></a>
@@ -62,6 +63,11 @@ class ControlBar {
         click: this.ui.selectFiles,
         hideIf: this.ui.boundToSingleFile,
         tips: "narrow-ui:select-files",
+      }),
+      inlineGitDiff: elementFor("inline-git-diff", {
+        click: this.ui.provider.toggleInlineGitDiff,
+        hideIf: this.ui.provider.dashName !== "git-diff-all",
+        tips: "inline-git-diff",
       }),
       searchIgnoreCase: elementFor("search-ignore-case", {
         click: this.ui.toggleSearchIgnoreCase,

--- a/lib/main.js
+++ b/lib/main.js
@@ -221,6 +221,10 @@ module.exports = {
     )
   },
 
+  consumeInlineGitDiff(service) {
+    ProviderBase.setService({inlineGitDiff: service})
+  },
+
   registerProvider(name, klassOrFilePath) {
     ProviderBase.registerProvider(name, klassOrFilePath)
   },

--- a/lib/provider/git-diff-all.js
+++ b/lib/provider/git-diff-all.js
@@ -1,6 +1,6 @@
 "use babel"
 
-const {Point} = require("atom")
+const {Point, Disposable} = require("atom")
 const _ = require("underscore-plus")
 const ProviderBase = require("./provider-base")
 const path = require("path")
@@ -58,6 +58,18 @@ module.exports = class GitDiffAll extends ProviderBase {
   constructor(...args) {
     super(...args)
     Object.assign(this, providerConfig)
+  }
+
+  onItemOpened(editor) {
+    if (!this.getConfig("inlineGitDiffIntegration") || !this.service.inlineGitDiff) return
+    if (!this.lastOpenedEditor || this.lastOpenedEditor !== editor) {
+      this.lastOpenedEditor = editor
+      const inlineGitDiff = this.service.inlineGitDiff.getInlineGitDiff(editor)
+      if (inlineGitDiff.enable()) {
+        // If inlineGitDiff was NOT already enabled we dispose it on narrow:close
+        this.subscriptions.add(new Disposable(() => inlineGitDiff.destroy()))
+      }
+    }
   }
 
   getItems({filePath}) {

--- a/lib/provider/git-diff-all.js
+++ b/lib/provider/git-diff-all.js
@@ -58,21 +58,53 @@ module.exports = class GitDiffAll extends ProviderBase {
   constructor(...args) {
     super(...args)
     Object.assign(this, providerConfig)
+    this.enabledInlineGitDiff = new Set()
+    this.subscriptions.add(new Disposable(() => this.destroyEnabledInlineGitDiff()))
+    this.toggleInlineGitDiff = this.toggleInlineGitDiff.bind(this)
   }
 
   onItemOpened(editor) {
-    if (!this.getConfig("inlineGitDiffIntegration") || !this.service.inlineGitDiff) return
-    if (!this.lastOpenedEditor || this.lastOpenedEditor !== editor) {
-      this.lastOpenedEditor = editor
-      const inlineGitDiff = this.service.inlineGitDiff.getInlineGitDiff(editor)
-      if (inlineGitDiff.enable()) {
-        // If inlineGitDiff was NOT already enabled we dispose it on narrow:close
-        this.subscriptions.add(new Disposable(() => inlineGitDiff.destroy()))
+    if (this.getConfig("inlineGitDiffIntegration")) {
+      if (this.lastOpenedEditor !== editor) {
+        this.lastOpenedEditor = editor
+        this.enabledInlineGitDiffForEditor(editor)
       }
     }
   }
 
+  enabledInlineGitDiffForEditor(editor) {
+    if (this.service.inlineGitDiff) {
+      const inlineGitDiff = this.service.inlineGitDiff.getInlineGitDiff(editor)
+      // If inlineGitDiff was NOT already enabled we dispose it on narrow:close
+      if (inlineGitDiff.enable()) {
+        this.enabledInlineGitDiff.add(inlineGitDiff)
+      }
+    }
+  }
+
+  destroyEnabledInlineGitDiff() {
+    this.enabledInlineGitDiff.forEach(diff => diff.destroy())
+    this.enabledInlineGitDiff.clear()
+  }
+
+  toggleInlineGitDiff() {
+    const enabled = !this.getConfig("inlineGitDiffIntegration")
+    this.setConfig("inlineGitDiffIntegration", enabled)
+    if (enabled) {
+      this.enabledInlineGitDiffForEditor(this.lastOpenedEditor)
+    } else {
+      this.destroyEnabledInlineGitDiff()
+    }
+    this.updateControlBar(enabled)
+  }
+
+  updateControlBar(value = this.getConfig("inlineGitDiffIntegration")) {
+    this.ui.controlBar.updateElements({inlineGitDiff: value})
+  }
+
   getItems({filePath}) {
+    this.updateControlBar()
+
     if (filePath) {
       const repo = repositoryForPath(filePath)
       if (repo) {

--- a/lib/provider/provider-base.js
+++ b/lib/provider/provider-base.js
@@ -58,6 +58,13 @@ module.exports = class ProviderBase {
   static providerPathsByName = {}
   static reopenableMax = 10
 
+  // Keep service by name
+  // service must be object like `{inlineGitDiff: service}`
+  static setService(service) {
+    if (!this.service) this.service = {}
+    Object.assign(this.service, service)
+  }
+
   static reopen() {
     const stateAtDestroyed = this.destroyedProviderStates.shift()
     if (stateAtDestroyed) {
@@ -102,6 +109,10 @@ module.exports = class ProviderBase {
         : atom.config.get(`${this.configScope}.${name}`)
 
     return value === "inherit" ? settings.get(name) : value
+  }
+
+  get service() {
+    return ProviderBase.service
   }
 
   getConfig(name) {
@@ -156,6 +167,9 @@ module.exports = class ProviderBase {
   // Event is object contains {newEditor, oldEditor}
   // to override
   onBindEditor(event) {}
+
+  // Currently used only in git-diff-all
+  onItemOpened(item) {}
 
   checkReady() {
     return true
@@ -323,7 +337,7 @@ module.exports = class ProviderBase {
   async openFileForItem({filePath}, {activatePane, pane} = {}) {
     if (!pane) pane = this.getPaneToOpenItem()
 
-    let itemToOpen = null
+    let itemToOpen
     if (this.boundToSingleFile && this.editor.isAlive() && pane === paneForItem(this.editor)) {
       itemToOpen = this.editor
     }
@@ -334,15 +348,17 @@ module.exports = class ProviderBase {
     if (itemToOpen) {
       if (activatePane) pane.activate()
       pane.activateItem(itemToOpen)
-      return itemToOpen
+    } else {
+      itemToOpen = await atom.workspace.open(filePath, {
+        pending: true,
+        activatePane,
+        activateItem: true,
+        pane: pane,
+      })
     }
 
-    return await atom.workspace.open(filePath, {
-      pending: true,
-      activatePane,
-      activateItem: true,
-      pane: pane,
-    })
+    this.onItemOpened(itemToOpen)
+    return itemToOpen
   }
 
   async confirmed(item, openAtUiPane = false) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -115,7 +115,13 @@ const otherProviderConfigs = {
   Symbols: {
     revealOnStartCondition: {default: "on-input"},
   },
-  GitDiffAll: {},
+  GitDiffAll: {
+    inlineGitDiffIntegration: {
+      titile: "`inline-git-diff` Integration",
+      default: true,
+      description: "Require install [inline-git-diff](https://atom.io/packages/inline-git-diff)",
+    },
+  },
   Fold: {
     revealOnStartCondition: {default: "on-input"},
     foldLevel: {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
       "versions": {
         "^0.1.0": "consumeVim"
       }
+    },
+    "inline-git-diff": {
+      "versions": {
+        "^1.0.0": "consumeInlineGitDiff"
+      }
     }
   },
   "providedServices": {

--- a/styles/narrow.less
+++ b/styles/narrow.less
@@ -171,6 +171,9 @@ atom-text-editor.narrow-editor {
     .select-files {
       .octicon(file-submodule, 1.0em);
     }
+    .inline-git-diff {
+      .octicon(octoface, 1.0em);
+    }
     .refresh {
       .octicon(repo-sync, 1.0em);
       &.running {


### PR DESCRIPTION
Added integration with [inline-git-diff](https://github.com/t9md/atom-inline-git-diff) pkg.

Depends https://github.com/t9md/atom-inline-git-diff/pull/3

## Scenario

- While reviewing changes before commit by `git-diff-all`.
- Show `inline-git-diff` which is auto-enabled on GitDiffProvider opened editor and diff disabled on ui destroy.
- Catch accidental removal remaining `console.log` etc..
- Revert is easy by `inline-git-diff:revert` command(I map it to `g r` for `editor.has-inline-git-diff` scope)

```CoffeeScript
'atom-workspace:not(.has-narrow) atom-text-editor.vim-mode-plus.normal-mode.has-inline-git-diff':
  'tab': 'git-diff:move-to-next-diff'
  'shift-tab': 'git-diff:move-to-previous-diff'

'atom-text-editor.vim-mode-plus.normal-mode.has-inline-git-diff':
  'g r': 'inline-git-diff:revert'
  'g c': 'inline-git-diff:copy-removed-text'
```

![narrow-git-diff-all-with-inline](https://user-images.githubusercontent.com/155205/35402273-68791470-023f-11e8-985a-8a17998f0fee.gif)
