### PR TITLE
Improve history handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 0.58.0:
+- Fix: No longer throw exception when `core:move-up`/`core:move-down` command was executed with empty items #276
+- Improve: History #277
+  - Tune when history is saved for `atom-scan`, `search`, `scan` provider(added confirm timing).
+  - When recall history No longer move to item when cursor is at prompt of narrow editor.
+  - History feature itself is not new, was provided by default keymap which is available globally as long as workspace `has-narrow`.
+    - `ctrl-cmd-[`(`narrow:previous-query-history`)
+    - `ctrl-cmd-]`(`narrow:next-query-history`)
+  - For user who want to recall history from narrow-editor's prompt as like normal search-tool, define following keymap in `keymap.cson`.
+    - NOTE: This is vim-mode-plus user specific example
+    ```coffeescript
+    'atom-text-editor.narrow.narrow-editor.vim-mode-plus.insert-mode.prompt':
+      # with up/down arrow key
+      'up': 'narrow:previous-query-history'
+      'down': 'narrow:next-query-history'
+
+      # or ctrl-p, ctrl-n
+      'ctrl-p': 'narrow:previous-query-history'
+      'ctrl-n': 'narrow:next-query-history'
+    ```
+
 # 0.57.1:
 - Fix: Regression where markerLayer for highlight `truncationIndicator` was not defined. #275
   - No longer throw error where narrow-editor have `[truncated]` and scroll to there.

--- a/lib/item-reducer.js
+++ b/lib/item-reducer.js
@@ -69,9 +69,11 @@ function toColumn (item) {
 
 function injectLineHeader (state) {
   let maxColumnWidth
-  if (state.hasCachedItems) return null
 
   const normalItems = state.items.filter(item => !item.skip)
+  if (normalItems.length && normalItems[0]._lineHeader) {
+    return null
+  }
   const maxRow = state.maxRow != null ? state.maxRow : normalItems.map(toRow).reduce(byMax, 0)
   const maxLineWidth = String(maxRow + 1).length
 
@@ -89,10 +91,10 @@ function injectLineHeader (state) {
   }
 }
 
-function spliceItemsForFilePath ({cachedNormalItems, spliceFilePath, items}) {
-  if (cachedNormalItems && spliceFilePath) {
+function spliceItemsForFilePath ({existingItems, spliceFilePath, items}) {
+  if (existingItems && spliceFilePath) {
     return {
-      items: replaceOrAppendItemsForFilePath(spliceFilePath, cachedNormalItems, items)
+      items: replaceOrAppendItemsForFilePath(spliceFilePath, existingItems, items)
     }
   }
 }
@@ -198,7 +200,7 @@ module.exports = class ItemReducer {
     this.reducers = [
       Reducer.spliceItemsForFilePath,
       config.showLineHeader && Reducer.injectLineHeader,
-      Reducer.collectAllItems,
+      Reducer.collectAllItems, // Correct BEFORE filter, insert file or project header
       Reducer.filterFilePath,
       Reducer.filterItems,
       config.showProjectHeader && Reducer.insertProjectHeader,

--- a/lib/query-history.js
+++ b/lib/query-history.js
@@ -4,7 +4,7 @@ const {getValidIndexForList} = require('./utils')
 class History {
   constructor (entries = []) {
     this.entries = entries
-    this.maxSize = 100
+    this.maxSize = 20
     this.index = -1
   }
 
@@ -70,8 +70,7 @@ class QueryHistory {
   }
 
   clear (name) {
-    const history = this.historyByProviderName[name]
-    if (history) history.clear()
+    delete this.historyByProviderName[name]
   }
 }
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -134,21 +134,25 @@ class Ui {
 
   setQueryFromHistroy (direction, retry) {
     const text = queryHistory.get(this.provider.name, direction)
-    if (!text) return
-
-    if (text === this.getQuery()) {
-      if (!retry) this.setQueryFromHistroy(direction, true) // retry
-    } else {
-      this.setQueryAndRefreshWithDelay(text, 100)
+    if (text) {
+      if (text === this.getQuery()) {
+        if (!retry) this.setQueryFromHistroy(direction, true) // retry
+        return
+      }
+      if (text) {
+        this.setQueryAndRefreshWithDelay(text, 100)
+      }
     }
   }
 
   setQueryAndRefreshWithDelay (text, delay) {
     this.narrowEditor.withIgnoreChange(() => this.setQuery(text))
     this.refreshWithDelay({force: true}, delay, () => {
-      this.moveToSearchedWordOrBeginningOfSelectedItem()
       if (!this.isActive()) this.scrollToColumnZero()
-      this.narrowEditor.flashCurrentRow()
+      if (!this.narrowEditor.isAtPrompt()) {
+        this.moveToSearchedWordOrBeginningOfSelectedItem()
+        this.narrowEditor.flashCurrentRow()
+      }
     })
   }
 
@@ -326,7 +330,9 @@ class Ui {
     }
 
     this.narrowEditor.withIgnoreChange(() => this.setQuery(this.query))
-    if (!this.reopened) this.saveQueryHistory(this.query)
+    if (!this.reopened && this.query) {
+      this.saveQueryHistory(this.query)
+    }
     this.controlBar.show()
 
     this.disposables.add(this.registerCommands())
@@ -425,7 +431,6 @@ class Ui {
     if (this.destroyed) return
 
     this.destroyed = true
-    this.saveQueryHistory(this.getQuery())
     this.resetHistory()
 
     // NOTE: Prevent delayed-refresh on destroyed editor.
@@ -551,8 +556,8 @@ class Ui {
 
   createStateToReduce () {
     return {
+      searchTerm: this.useFirstQueryAsSearchTerm ? this.narrowEditor.getSearchTerm() : undefined,
       reduced: false,
-      hasCachedItems: this.items.cachedItems != null,
       showColumn: this.showColumnOnLineHeader,
       maxRow: this.boundToSingleFile ? this.provider.editor.getLastBufferRow() : undefined,
       boundToSingleFile: this.boundToSingleFile,
@@ -657,38 +662,32 @@ class Ui {
 
     this.lastQuery = this.getQuery()
 
-    let searchTerm
-    if (this.useFirstQueryAsSearchTerm) {
-      searchTerm = this.narrowEditor.getSearchTerm()
-      if (this.lastSearchTerm !== searchTerm) {
-        this.lastSearchTerm = searchTerm
-        force = true
-      }
+    const state = this.createStateToReduce()
+    this.filterSpec = state.filterSpec // preserve to use for highlight narrow-editor
+    if (this.supportFilePathOnlyItemsUpdate && event.filePath && this.items.cachedItems) {
+      Object.assign(state, {
+        existingItems: this.items.cachedItems.filter(item => !item.skip),
+        spliceFilePath: event.filePath
+      })
     }
 
-    const spliceFilePath = event.filePath
-    let cachedNormalItems
-    if (this.supportFilePathOnlyItemsUpdate && spliceFilePath && this.items.cachedItems) {
-      cachedNormalItems = this.items.cachedItems.filter(item => !item.skip)
+    if (state.searchTerm != null && this.lastSearchTerm !== state.searchTerm) {
+      this.lastSearchTerm = state.searchTerm
+      force = true
     }
-
-    if (force) this.items.clearCachedItems()
+    if (force) {
+      this.items.clearCachedItems()
+    }
 
     // Preparation to reduce updated items
     // ===================================
     let resolveGetItem
-    const getItemPromise = new Promise(resolve => {
-      resolveGetItem = resolve
-    })
+    const getItemPromise = new Promise(resolve => (resolveGetItem = resolve))
 
-    const state = this.createStateToReduce()
     // Preserve oldSelectedItem before calling this.items.reset()
     const oldSelectedItem = this.items.getSelectedItem()
     const oldColumn = this.editor.getCursorBufferPosition().column
     const wasAtPrompt = this.narrowEditor.isAtPrompt()
-
-    this.filterSpec = state.filterSpec // preserve to use for highlight narrow-editor
-    Object.assign(state, {cachedNormalItems, spliceFilePath})
 
     const onFinishUpdateItems = () => {
       // When finished with no update(reduceItems). E.g. Search find no matches.
@@ -703,7 +702,9 @@ class Ui {
         this.updateFilePathsForAllItemsFromState(state)
       }
 
-      if (this.supportCacheItems) this.items.setCachedItems(state.allItems)
+      if (this.supportCacheItems) {
+        this.items.setCachedItems(state.allItems)
+      }
 
       if (selectFirstItem) {
         this.items.selectFirstNormalItem()
@@ -743,8 +744,8 @@ class Ui {
       this.emitDidUpdateItems(this.items.cachedItems)
       this.emitDidFinishUpdateItems()
     } else {
-      if (searchTerm != null) {
-        this.updateSearchOptions(searchTerm)
+      if (state.searchTerm != null) {
+        this.updateSearchOptions(state.searchTerm)
       }
       this.provider.getItems(event)
     }
@@ -826,6 +827,11 @@ class Ui {
   }
 
   async confirm ({keepOpen, flash, openAtUiPane} = {}) {
+    if (this.useFirstQueryAsSearchTerm) {
+      if (this.lastSearchTerm) {
+        this.saveQueryHistory(this.lastSearchTerm)
+      }
+    }
     const item = this.items.getSelectedItem()
     if (!item) return
 


### PR DESCRIPTION
Summary

- Do not auto-visit item when cursor is at prompt.
- For `atom-scan`, `search`, `scan` provider, save history on confirm in addition to existing save timing.


History feature itself was provided from older version with default keymap.

- `ctrl-cmd-[`(`narrow:previous-query-history`)
- `ctrl-cmd-]`(`narrow:next-query-history`)

User can recall query-history from both inside and outside(when narrow-editor is not focused) narrrow-editor.

But for user who want to recall query-history from narrow-editor's prompt as like normal search-tool, define following keymap in `keymap.cson`.

:warning: NOTE: This is vim-mode-plus user specific example!! :warning:

```coffeescript
'atom-text-editor.narrow.narrow-editor.vim-mode-plus.insert-mode.prompt':
  # with up/down arrow key
  'up': 'narrow:previous-query-history'
  'down': 'narrow:next-query-history'

  # or ctrl-p, ctrl-n
  'ctrl-p': 'narrow:previous-query-history'
  'ctrl-n': 'narrow:next-query-history'
```
