### PR TITLE
auto-append-space after query when user's explicit move-to-prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.59.0:
+- Improve, Experiment: Automatically append space at end of query on `move-to-prompt` to input next query immediately #278.
+
 # 0.58.0:
 - Fix: No longer throw exception when `core:move-up`/`core:move-down` command was executed with empty items #276
 - Improve: History #277

--- a/lib/narrow-editor.js
+++ b/lib/narrow-editor.js
@@ -279,7 +279,14 @@ class NarrowEditor {
 
   // Extended move or predict
   // -------------------------
-  moveToPrompt () {
+  moveToPrompt ({appendSpaceAfterQuery = false} = {}) {
+    if (appendSpaceAfterQuery) {
+      if (!this.editor.lineTextForBufferRow(PROMPT_ROW).endsWith(' ')) {
+        this.withIgnoreChange(() => {
+          this.editor.setTextInBufferRange([PROMPT_RANGE.end, PROMPT_RANGE.end], ' ')
+        })
+      }
+    }
     this.editor.setCursorBufferPosition(PROMPT_RANGE.end)
     this.setReadOnly(false)
   }

--- a/lib/narrow-editor.js
+++ b/lib/narrow-editor.js
@@ -281,7 +281,8 @@ class NarrowEditor {
   // -------------------------
   moveToPrompt ({appendSpaceAfterQuery = false} = {}) {
     if (appendSpaceAfterQuery) {
-      if (!this.editor.lineTextForBufferRow(PROMPT_ROW).endsWith(' ')) {
+      const promptLine = this.editor.lineTextForBufferRow(PROMPT_ROW)
+      if (promptLine && !promptLine.endsWith(' ')) {
         this.withIgnoreChange(() => {
           this.editor.setTextInBufferRange([PROMPT_RANGE.end, PROMPT_RANGE.end], ' ')
         })

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -106,7 +106,7 @@ class Ui {
       'narrow-ui:preview-previous-item': () => this.previewItemForDirection('previous'),
       'narrow-ui:toggle-auto-preview': () => this.toggleAutoPreview(),
       'narrow-ui:move-to-prompt-or-selected-item': () => this.narrowEditor.moveToPromptOrSelectedItem(),
-      'narrow-ui:move-to-prompt': () => this.moveToPrompt(),
+      'narrow-ui:move-to-prompt': () => this.moveToPrompt({appendSpaceAfterQuery: true}),
       'narrow-ui:start-insert': () => this.narrowEditor.setReadOnly(false),
       'narrow-ui:stop-insert': () => this.narrowEditor.setReadOnly(true),
       'narrow-ui:update-real-file': () => this.updateRealFile(),
@@ -396,7 +396,7 @@ class Ui {
       this.activateProviderPane()
     } else {
       if (!this.isActive()) this.focus()
-      this.moveToPrompt()
+      this.moveToPrompt({appendSpaceAfterQuery: true})
     }
   }
 
@@ -879,8 +879,8 @@ class Ui {
     this.editor.setCursorBufferPosition(point)
   }
 
-  moveToPrompt () {
-    this.narrowEditor.moveToPrompt()
+  moveToPrompt (options) {
+    this.narrowEditor.moveToPrompt(options)
   }
 
   startSyncToEditor (editor) {


### PR DESCRIPTION
automatically append single space `' '` when user execute `move-to-prompt` command so that user can continue new query immediately.
This is auto-append have pros and cons.
I won't say improvement for everyone.
Will see reaction in the wild.
