### PR TITLE
restore vmp's pane-maximized-state on ui destroyed

### DIFF
--- a/lib/provider/provider.js
+++ b/lib/provider/provider.js
@@ -2,6 +2,7 @@ const _ = require('underscore-plus')
 const {CompositeDisposable} = require('atom')
 const {
   saveEditorState,
+  saveVmpPaneMaximizedState,
   isActiveEditor,
   paneForItem,
   getNextAdjacentPaneForPane,
@@ -223,6 +224,10 @@ class Provider {
     }
     this.restoreEditorState = saveEditorState(this.editor)
 
+    if (settings.get('restoreVmpPaneMaximizedStateOnUiClosed')) {
+      this.restoreVmpPaneMaximizedState = saveVmpPaneMaximizedState()
+    }
+
     this.query = this.getInitialQuery(this.clientEditor, options)
     if (this.showSearchOption) {
       const props = this.searchOptionState || this.buildSearchOptionsProps(options)
@@ -266,6 +271,12 @@ class Provider {
 
   restoreEditorStateIfNecessary (...args) {
     if (this.needRestoreEditorState) this.restoreEditorState(...args)
+  }
+
+  restoreVmpPaneMaximizedStateIfNecessary () {
+    if (this.restoreVmpPaneMaximizedState) {
+      this.restoreVmpPaneMaximizedState()
+    }
   }
 
   destroy () {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -52,6 +52,10 @@ const globalSettings = {
     description:
       'Used in multi-file provider such as `search`, `git-diff-all`.<br>`___HEADER__` is replaced with actual file-path.<br>E.g `## __HEADER__`'
   },
+  restoreVmpPaneMaximizedStateOnUiClosed: {
+    default: true,
+    description: "Restore `vim-mode-plus`'s pane maximize state when ui closed."
+  },
   notifiedVimModePlusSpecificDefaultKeymap: {
     default: false,
     description: 'Just for manage one-time notification status will be removed in near future'

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -448,6 +448,9 @@ class Ui {
     this.controlBar.destroy()
     if (this.provider) this.provider.destroy()
     this.items.destroy()
+
+    this.provider.restoreVmpPaneMaximizedStateIfNecessary()
+
     this.emitDidDestroy()
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,6 +34,23 @@ function splitPane (basePane, {split}) {
   return pane
 }
 
+function saveVmpPaneMaximizedState () {
+  const classList = atom.workspace.getElement().classList
+
+  if (!classList.contains('vim-mode-plus--pane-maximized')) {
+    return
+  }
+  let command
+  if (classList.contains('vim-mode-plus--pane-centered')) {
+    command = 'vim-mode-plus:maximize-pane'
+  } else {
+    command = 'vim-mode-plus:maximize-pane-without-center'
+  }
+  return () => {
+    atom.commands.dispatch(atom.workspace.getElement(), command)
+  }
+}
+
 function saveEditorState (editor) {
   const oldScrollTop = editor.element.getScrollTop()
   const oldCursorPosition = editor.getCursorBufferPosition()
@@ -294,6 +311,7 @@ module.exports = {
   getPreviousAdjacentPaneForPane,
   splitPane,
   saveEditorState,
+  saveVmpPaneMaximizedState,
   requireFrom,
   limitNumber,
   getCurrentWord,


### PR DESCRIPTION
vmp have feature to maximize currently active pane by `cmd-enter` etc..

Basically this maximized state is restored(unmaximized) when pane split happened.
Since narrow open narrow-editor with splitting-pane, opening narrow always de-maximize this maximized-state.

This PR re-maximize pane when narrow-editor(=ui) was closed if it's originally maximized.
Default enabled, but user can disable this by configuration `restoreVmpPaneMaximizedStateOnUiClosed`.
