### PR TITLE
dont start auto-preview when cursor is at prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # 0.60.1:
+- Fix: When `narrow:scan` start without any input, don't preview first row item #281
+  - This is regression introduced in v0.60.0.
+  - Plus: No longer start auto-preview when prompt query was clicked.
+
+# 0.60.1:
 - Fix: RegExp search for `search`, `atom-scan`, `scan` didn't work because of regression.
   - After v0.57.0.
 - Style: Modify match color and line-marker color.

--- a/lib/main.js
+++ b/lib/main.js
@@ -119,7 +119,7 @@ module.exports = {
       if (isNarrowEditor(item)) {
         this.lastFocusedNarrowEditor = item
         const ui = Ui.get(item)
-        if (ui.autoPreview) {
+        if (ui && !ui.narrowEditor.isAtPrompt() && ui.autoPreview) {
           ui.previewWithDelay()
         }
         return


### PR DESCRIPTION
Fix #281 
- Fix: When `narrow:scan` start without any input, don't preview first row item #281
  - This is regression introduced in v0.60.0.
  - Plus: No longer start auto-preview when prompt query was clicked.
