### PR TITLE
atom-scan now direct-editable again

### DIFF
--- a/lib/narrow-editor.js
+++ b/lib/narrow-editor.js
@@ -446,8 +446,8 @@ class NarrowEditor {
 
       // We can not highlight item without range info
       if (item.range) {
-        const range = item.translateRange ? item.translateRange() : item.range
-        markRange('searchTerm', [[row, range.start.column + totalLength], [row, range.end.column + totalLength]])
+        const {start, end} = item.range
+        markRange('searchTerm', [[row, start.column + totalLength], [row, end.column + totalLength]])
       }
 
       if (includeFilters) {

--- a/lib/provider/atom-scan.js
+++ b/lib/provider/atom-scan.js
@@ -2,23 +2,8 @@ const {Range} = require('atom')
 const Provider = require('./provider')
 const {scanItemsForFilePath} = require('../utils')
 
-function createItemsFromScanResult ({filePath, matches}) {
-  return matches.map(({range, lineText, lineTextOffset}) => {
-    range = Range.fromObject(range)
-    return {
-      filePath: filePath,
-      text: lineText,
-      point: range.start,
-      range: range,
-      translateRange () {
-        return this.range.translate([0, -lineTextOffset])
-      }
-    }
-  })
-}
-
 const Config = {
-  supportDirectEdit: false,
+  supportDirectEdit: true,
   showColumnOnLineHeader: true,
   showProjectHeader: true,
   showFileHeader: true,
@@ -50,6 +35,21 @@ module.exports = class AtomScan {
     return this.provider.start(options)
   }
 
+  async itemizeResult ({filePath, matches}) {
+    const buffer = await atom.project.bufferForPath(filePath)
+    const items = []
+    for (const match of matches) {
+      const range = Range.fromObject(match.range)
+      items.push({
+        filePath: filePath,
+        text: buffer.lineForRow(range.start.row),
+        point: range.start,
+        range: range
+      })
+    }
+    this.provider.updateItems(items)
+  }
+
   async getItems ({filePath}) {
     if (this.scanPromise) this.scanPromise.cancel()
 
@@ -65,9 +65,10 @@ module.exports = class AtomScan {
         this.provider.finishUpdateItems([])
       }
     } else {
+      const itemizePromises = []
       this.scanPromise = atom.workspace.scan(searchRegex, result => {
         if (result && result.matches && result.matches.length) {
-          this.provider.updateItems(createItemsFromScanResult(result))
+          itemizePromises.push(this.itemizeResult(result))
         }
       })
 
@@ -77,6 +78,7 @@ module.exports = class AtomScan {
         // Relying on Atom's workspace.scan's specific implementation
         // `workspace.scan` return cancellable promise.
         // When cancelled, promise is NOT rejected, instead it's resolved with 'cancelled' message
+        await Promise.all(itemizePromises)
         this.provider.finishUpdateItems()
       }
     }


### PR DESCRIPTION
### History of `directEdit` support for `atom-scan` provider

- `atom-scan` provider originally supported `directEdit` feature
- But I [removed this feature](d1f5416) when I noticed something dangerous could be happen in `atom-scan` provder.
  - Why? `atom-scan` use `workspace.scan` which returns **truncated lineText**(truncation happens both in leading or trailing place).
  - `update-real-file`(direct-edit) is done by **replacing exiting-whole-line-text with new-whole-line-text**, cannot/won't handle replacing partial text.
- Now: I'm trying to re-introduce this feature(come back!) with keep in mind `workspace.scan`'s result is **truncated**.
By ignoring result.lineText and use real buffer’s non-truncated


### How? Why? Possible approaches

#### Truncation indicator

- `workspace.scan`'s result have `linetText` and `lineTextOffset`
- `lineText` might be **truncated**
  - Leading truncation: When `lineTextOffset > 0 `
  - Trainling truncation: No indicator from `result`. Detectable by comparing `lineText.length` with actual lineText(`buffer.lineForRow(row).length`).

#### But I don't use this

- I might be able to build whole-line at write timing by building whole-line-text from above indicators.
- I might be able to add new replacement logic which replace **partial text** in line, instead of current whole-line-text replacement.
- **But I won't I don't want to do these hardworking, and keep `update-real-file` logic simple and also consistent with other provider which support `direct-edit`(`scan`, `search`).**

#### Changes introduced in this PR.

- When `atom-scan` create items, it no longer user `lineText` and `lineTextOffset` information given by `workspace.scan`'s `result`.
- Instead it ask non-truncated `lineText` directly to `buffer` instance by `buffer.lineForRow(row)`.
- So we can forget `atom-scan`'s truncation, and also can forget dynamic range translation using `lineTextOffset` when highlight range.
- It might introduce slight performance overhead. But I don't mind at this point, I prefer simplicity, consistency, less-danger to make this aggressive feature less awkward.
