### PR TITLE
simplify getItems, no longer require to call finishUpdateItems

### DIFF
--- a/lib/provider/atom-scan.js
+++ b/lib/provider/atom-scan.js
@@ -55,14 +55,14 @@ module.exports = class AtomScan {
 
     const {searchRegex} = this.provider.searchOptions
     if (!searchRegex) {
-      return this.provider.finishUpdateItems([])
+      return []
     }
 
     if (filePath) {
       if (atom.project.contains(filePath)) {
-        this.provider.finishUpdateItems(await scanItemsForFilePath(filePath, searchRegex))
+        return scanItemsForFilePath(filePath, searchRegex)
       } else {
-        this.provider.finishUpdateItems([])
+        return []
       }
     } else {
       const itemizePromises = []
@@ -79,7 +79,7 @@ module.exports = class AtomScan {
         // `workspace.scan` return cancellable promise.
         // When cancelled, promise is NOT rejected, instead it's resolved with 'cancelled' message
         await Promise.all(itemizePromises)
-        this.provider.finishUpdateItems()
+        return []
       }
     }
   }

--- a/lib/provider/fold.js
+++ b/lib/provider/fold.js
@@ -48,11 +48,9 @@ module.exports = class Fold {
   getItems () {
     const editor = this.provider.editor
     const foldStartRows = getCodeFoldStartRows(editor, settings.get('Fold.foldLevel'))
-    this.provider.finishUpdateItems(
-      foldStartRows.map(row => ({
-        point: getFirstCharacterPositionForBufferRow(editor, row),
-        text: editor.lineTextForBufferRow(row)
-      }))
-    )
+    return foldStartRows.map(row => ({
+      point: getFirstCharacterPositionForBufferRow(editor, row),
+      text: editor.lineTextForBufferRow(row)
+    }))
   }
 }

--- a/lib/provider/git-diff-all.js
+++ b/lib/provider/git-diff-all.js
@@ -123,20 +123,21 @@ module.exports = class GitDiffAll {
     if (filePath) {
       const repo = repositoryForPath(filePath)
       const items = repo ? await getItemsForFilePath(repo, filePath) : []
-      this.provider.finishUpdateItems(items)
+      return items
     } else {
       const promises = []
-      const updateItems = items => this.provider.updateItems(items.filter(v => v))
 
-      const repositories = atom.project.getRepositories().filter(repo => repo)
+      const repositories = atom.project.getRepositories().filter(v => v)
       for (const repo of repositories) {
         for (const filePath of getModifiedFilePathsForRepository(repo)) {
-          const promise = getItemsForFilePath(repo, filePath).then(updateItems)
+          const promise = getItemsForFilePath(repo, filePath).then(items => {
+            this.provider.updateItems(items.filter(v => v))
+          })
           promises.push(promise)
         }
       }
       await Promise.all(promises)
-      this.provider.finishUpdateItems()
+      return []
     }
   }
 }

--- a/lib/provider/project-symbols.js
+++ b/lib/provider/project-symbols.js
@@ -124,10 +124,8 @@ module.exports = class ProjectSymbols {
     // Refresh watching target tagFile on each execution to catch-up change in outer-world.
     watchTagsFiles()
 
-    const cache = getCachedItems()
-    if (cache) {
-      this.provider.finishUpdateItems(cache)
-    } else {
+    let items = getCachedItems()
+    if (!items) {
       const tags = await new Promise(resolve => {
         this.loadTagsTask = TagReader.getAllTags(resolve)
       })
@@ -135,14 +133,15 @@ module.exports = class ProjectSymbols {
       // Better interests suggestion? I want this less noisy.
       // kinds cab be listed by `ctags --list-kinds`
       const kindOfInterests = 'cfmr'
-      let items = tags
+      items = tags
         .filter(tag => kindOfInterests.includes(tag.kind))
         .map(itemForTag)
         .filter(item => item.point != null)
         .sort(compareByPoint)
       items = _.uniq(items, item => item.filePath + item.text)
       setCachedItems(items)
-      this.provider.finishUpdateItems(items)
     }
+
+    return items
   }
 }

--- a/lib/provider/provider.js
+++ b/lib/provider/provider.js
@@ -184,7 +184,6 @@ class Provider {
 
     this.getItems = options.getItems
     this.updateItems = this.updateItems.bind(this)
-    this.finishUpdateItems = this.finishUpdateItems.bind(this)
 
     this.hook = {
       willOpenUi: options.willOpenUi,
@@ -260,11 +259,6 @@ class Provider {
 
   updateItems (items) {
     this.ui.emitDidUpdateItems(items)
-  }
-
-  finishUpdateItems (items) {
-    if (items) this.updateItems(items)
-    this.ui.emitDidFinishUpdateItems()
   }
 
   getInitialQuery (editor, options) {

--- a/lib/provider/scan.js
+++ b/lib/provider/scan.js
@@ -39,7 +39,10 @@ module.exports = class Scan {
   getItems () {
     const {searchRegex} = this.provider.searchOptions
     const buffer = this.provider.editor.buffer
-    const items = searchRegex ? scanItemsForBuffer(buffer, searchRegex) : buffer.getLines().map(itemize)
-    this.provider.finishUpdateItems(items)
+    if (searchRegex) {
+      return scanItemsForBuffer(buffer, searchRegex)
+    } else {
+      return buffer.getLines().map(itemize)
+    }
   }
 }

--- a/lib/provider/scan.js
+++ b/lib/provider/scan.js
@@ -2,15 +2,6 @@ const {Point, Range} = require('atom')
 const Provider = require('./provider')
 const {scanItemsForBuffer} = require('../utils')
 
-function itemize (text, row) {
-  const point = new Point(row, 0)
-  return {
-    text: text,
-    point: point,
-    range: new Range(point, point)
-  }
-}
-
 const Config = {
   boundToSingleFile: true,
   supportDirectEdit: true,
@@ -42,7 +33,14 @@ module.exports = class Scan {
     if (searchRegex) {
       return scanItemsForBuffer(buffer, searchRegex)
     } else {
-      return buffer.getLines().map(itemize)
+      return buffer.getLines().map((text, row) => {
+        const point = new Point(row, 0)
+        return {
+          text: text,
+          point: point,
+          range: new Range(point, point)
+        }
+      })
     }
   }
 }

--- a/lib/provider/search.js
+++ b/lib/provider/search.js
@@ -52,6 +52,7 @@ module.exports = class Search {
     }
   }
 
+  // Return promise
   search () {
     const projectsToSearch = this.projects.slice()
     const modifiedBuffers = atom.project.getBuffers().filter(buffer => buffer.isModified() && buffer.getPath())
@@ -64,6 +65,11 @@ module.exports = class Search {
         modifiedBuffersScanned.add(buffer)
       }
     }
+
+    let resolveSearchPromise
+    const searchPromise = new Promise(resolve => {
+      resolveSearchPromise = resolve
+    })
 
     let finished = 0
     const onFinish = project => {
@@ -79,7 +85,7 @@ module.exports = class Search {
       }
 
       if (finished === this.projects.length) {
-        this.provider.finishUpdateItems()
+        resolveSearchPromise()
       }
     }
 
@@ -97,6 +103,8 @@ module.exports = class Search {
     } else {
       while (projectsToSearch.length) searchNextProject()
     }
+
+    return searchPromise
   }
 
   updateItems (items) {
@@ -110,23 +118,24 @@ module.exports = class Search {
 
     const executable = await this.isExecutable(searcher)
     if (!executable) {
-      return this.provider.finishUpdateItems([])
+      return []
     }
 
     const {searchRegex} = this.provider.searchOptions
     if (!searchRegex) {
-      return this.provider.finishUpdateItems([])
+      return []
     }
 
     this.searcher.setCommand(searcher)
     if (filePath) {
       if (atom.project.contains(filePath)) {
-        this.provider.finishUpdateItems(await scanItemsForFilePath(filePath, searchRegex))
+        return scanItemsForFilePath(filePath, searchRegex)
       } else {
-        this.provider.finishUpdateItems([])
+        return []
       }
     } else {
-      this.search()
+      await this.search()
+      return []
     }
   }
 

--- a/lib/provider/select-files.js
+++ b/lib/provider/select-files.js
@@ -45,13 +45,11 @@ module.exports = class SelectFiles {
 
   getItems () {
     const filePaths = this.clientUi.getFilePathsForAllItems()
-    this.provider.finishUpdateItems(
-      filePaths.map(filePath => ({
-        text: relativizeFilePath(filePath),
-        filePath,
-        point: new Point(0, 0)
-      }))
-    )
+    return filePaths.map(filePath => ({
+      text: relativizeFilePath(filePath),
+      filePath,
+      point: new Point(0, 0)
+    }))
   }
 
   // Must return undefined, when non null value was returned

--- a/lib/provider/symbols.js
+++ b/lib/provider/symbols.js
@@ -63,7 +63,6 @@ module.exports = class Symbols {
       const tags = await new TagGenerator(editor.getPath(), editor.getGrammar().scopeName).generate()
       this.items = _.uniq(tags, tag => tag.position.row).map(tag => itemForTag(editor, tag))
     }
-
-    this.provider.finishUpdateItems(this.items)
+    return this.items
   }
 }

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -793,17 +793,13 @@ class Ui {
     this.cancelRefresh()
 
     if (success) {
-      if (!this.boundToSingleFile) {
-        this.updateFilePathsForAllItemsFromState(state)
-      }
+      if (!this.boundToSingleFile) this.updateFilePathsForAllItemsFromState(state)
+      if (this.supportCacheItems) this.items.setCachedItems(state.allItems)
 
-      if (this.supportCacheItems) {
-        this.items.setCachedItems(state.allItems)
-      }
-
-      if (selectFirstItem) {
+      if (selectFirstItem || !oldSelectedItem) {
         this.items.selectFirstNormalItem()
-      } else if (oldSelectedItem) {
+        this.moveToPrompt()
+      } else {
         this.items.selectEqualLocationItem(oldSelectedItem)
         if (!this.items.hasSelectedItem()) {
           this.items.selectFirstNormalItem()
@@ -811,9 +807,6 @@ class Ui {
         if (!wasAtPrompt) {
           this.narrowEditor.moveToItem(this.items.getSelectedItem(), oldColumn)
         }
-      } else {
-        this.items.selectFirstNormalItem()
-        this.moveToPrompt()
       }
 
       this.controlBar.updateElements({

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -637,7 +637,6 @@ class Ui {
   createStateToReduce () {
     return {
       searchTerm: this.useFirstQueryAsSearchTerm ? this.narrowEditor.getSearchTerm() : undefined,
-      reduced: false,
       showColumn: this.showColumnOnLineHeader,
       maxRow: this.boundToSingleFile ? this.provider.editor.getLastBufferRow() : undefined,
       boundToSingleFile: this.boundToSingleFile,
@@ -759,25 +758,41 @@ class Ui {
       this.items.clearCachedItems()
     }
 
-    // Preparation to reduce updated items
-    // ===================================
-    let resolveGetItem
-    const getItemPromise = new Promise(resolve => (resolveGetItem = resolve))
+    this.refreshDisposables = new CompositeDisposable(
+      this.startUpdateControlBar(),
+      this.onDidUpdateItems(items => {
+        state.items = items
+        this.itemReducer.reduce(state)
+      })
+    )
 
+    // Main
+    // =======================
     // Preserve oldSelectedItem before calling this.items.reset()
     const oldSelectedItem = this.items.getSelectedItem()
     const oldColumn = this.editor.getCursorBufferPosition().column
     const wasAtPrompt = this.narrowEditor.isAtPrompt()
 
-    const onFinishUpdateItems = () => {
-      // When finished with no update(reduceItems). E.g. Search find no matches.
-      // Force update with empty items to render no items.
-      if (!state.reduced) {
-        this.emitDidUpdateItems([])
+    this.items.reset()
+
+    let success = false
+    if (this.items.cachedItems) {
+      this.emitDidUpdateItems(this.items.cachedItems)
+      success = true
+    } else {
+      if (state.searchTerm != null) {
+        this.updateSearchOptions(state.searchTerm)
       }
+      const items = await this.provider.getItems(event)
+      if (items) {
+        this.emitDidUpdateItems(items)
+        success = true
+      }
+    }
 
-      this.cancelRefresh()
+    this.cancelRefresh()
 
+    if (success) {
       if (!this.boundToSingleFile) {
         this.updateFilePathsForAllItemsFromState(state)
       }
@@ -806,33 +821,10 @@ class Ui {
         itemCount: this.items.getNormalItemCount(),
         refresh: false
       })
-      resolveGetItem()
+
+      this.emitDidRefresh()
+      this.emitDidStopRefreshing()
     }
-
-    this.refreshDisposables = new CompositeDisposable(
-      this.startUpdateControlBar(),
-      this.onDidUpdateItems(items => {
-        this.itemReducer.reduce(Object.assign(state, {items, reduced: true}))
-      }),
-      this.onDidFinishUpdateItems(onFinishUpdateItems)
-    )
-
-    // Main
-    // =======================
-    this.items.reset()
-    if (this.items.cachedItems) {
-      this.emitDidUpdateItems(this.items.cachedItems)
-      this.emitDidFinishUpdateItems()
-    } else {
-      if (state.searchTerm != null) {
-        this.updateSearchOptions(state.searchTerm)
-      }
-      this.provider.getItems(event)
-    }
-
-    await getItemPromise
-    this.emitDidRefresh()
-    this.emitDidStopRefreshing()
   }
 
   refreshManually () {


### PR DESCRIPTION
This is breaking change.
How? `provider.finishUpdateItems` method was removed.
This affect how `getItems()` should be implemented.

Related: #207, #272 

## Old style

### Single update

If all items are collectable synchronously, call `finishUpdateItems` with items.

```javascript
getItems() {
  this.provider.finishUpdateItems(items)
}
```

If items are collected async with multiple separate chunks, call `updateItems` multiple times, then call `finishUpdateItems` to notify **done**.

### Async multiple updates

```javascript
async getItems() {
  await new Promise(resolve) {
    this.provider.updateItems(items)
    this.provider.updateItems(items)
    this.provider.updateItems(items)
    resolve()
  }
  this.provider.finishUpdateItems()
}
```

## New

The `finishUpdateItems` method is removed, `return` items instead.

### Single update

If all items are collectable synchronously, return items.

```javascript
getItems() {
  return items
}
```

If items are collected async with multiple separate chunks, call `updateItems` multiple times, then return empty array when it's **done**.

### Async multiple updates

```javascript
async getItems() {
  await new Promise(resolve) {
    this.provider.updateItems(items)
    this.provider.updateItems(items)
    this.provider.updateItems(items)
    resolve()
  }
  return [] // must return empty array. Returning nothing means cancellation.
}
```

### Cancellation

When cancelled, no item rendered to narrow-editor.
How to cancel? Just return nothing.

```javascript
getItems() {
  // Returning nothing means cancellation.
  return
}
```
