### PR TITLE
Add another one highlighter layer - "group"

### DIFF
--- a/lib/narrow-editor.js
+++ b/lib/narrow-editor.js
@@ -83,6 +83,7 @@ class NarrowEditor {
       includeFilter: 'narrow-syntax--include-filter',
       fileHeader: 'narrow-syntax--header-file',
       projectHeader: 'narrow-syntax--header-project',
+      groupHeader: 'narrow-syntax--header-group',
       truncationIndicator: 'narrow-syntax--truncation-indicator'
     })
   }
@@ -435,6 +436,8 @@ class NarrowEditor {
           layerName = 'fileHeader'
         } else if (item.headerType === 'project') {
           layerName = 'projectHeader'
+        } else if (item.headerType === 'group') {
+          layerName = 'groupHeader'
         }
         markRange(layerName, [[row, 0], [row, Infinity]])
         continue

--- a/styles/narrow.less
+++ b/styles/narrow.less
@@ -89,7 +89,9 @@ atom-text-editor {
   .narrow-syntax--header-file {
     color: @syntax-color-variable;
   }
-
+  .narrow-syntax--header-group {
+    color: @syntax-color-class;
+  }
   .line.narrow-cursor-line-flash-short {
     .flash(narrow-editor-cursor-line-flash-short, 0.5s);
   }


### PR DESCRIPTION
I think it can be useful for third-party providers to has an ability to splits some results into the groups (already useful for me, on the "provider" that I am developing)
![image](https://user-images.githubusercontent.com/8239290/67654004-128cc180-f95d-11e9-8f15-8ca1893b9306.png)
