### PR TITLE
fix: Update Real File w/ confirmation prompt

### DIFF
--- a/lib/update-real-file.js
+++ b/lib/update-real-file.js
@@ -66,11 +66,18 @@ module.exports = async function updateRealFile (ui) {
 
   if (settings.get('confirmOnUpdateRealFile')) {
     const options = {message: 'Update real file?', buttons: ['Update', 'Cancel']}
-    if (atom.confirm(options) !== 0) return
+    atom.confirm(options, async (selectedButtonIndex) => {
+      if (selectedButtonIndex === 0) {
+        updateRealFileHelper(ui)
+      }
+    })
+  } else {
+    updateRealFileHelper(ui)
   }
+}
 
+async function updateRealFileHelper(ui) {
   if (ui.narrowEditor.itemRowIsDeleted()) return
-
   if (!ensurePrefixedTextAreNotMutated(ui)) return
 
   const changes = []
@@ -90,6 +97,7 @@ module.exports = async function updateRealFile (ui) {
 
   if (!ensureNoTruncatedItemInChanges(changes)) return
   if (!ensureNoConflictForChanges(changes)) return
+
   await ui.provider.updateRealFile(changes)
   ui.narrowEditor.setModifiedState(false)
 }


### PR DESCRIPTION
pass `atom.confirm` a callback allowing async handling
of user confirmation