### PR TITLE
increase autopreview timeout delay

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -830,7 +830,7 @@ class Ui {
       this.delayedPreviewTimeout = null
     }
 
-    const timeout = this.workspaceHasSelectedItem() ? 0 : 20
+    const timeout = this.workspaceHasSelectedItem() ? 0 : 600
     this.delayedPreviewTimeout = setTimeout(() => {
       this.delayedPreviewTimeout = null
       this.preview()


### PR DESCRIPTION
I type furiously fast, but it's not 50 characters in second. And often some minified/binary files gets previewed and atom synchronously tries to render the file, which blocks narrow. And so I wait unneeded rendering. And then you type new letter and it blocks again

[300 ms is considered as human reaction time](https://www.healthline.com/health/how-to-improve-reaction-time#:~:text=A%20typical%20human%20reaction%20time%20is%20200%20to%20300%20milliseconds.&text=The%20less%20distance%20the%20ruler,the%20faster%20your%20reaction%20time.) so its safe interval. But nobody print 3 symbols in second, so double it will make good timeout